### PR TITLE
Require leading, no trailing, and unitless zeros

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ module.exports = {
 		"function-url-quotes": [ "none" ],
 		"function-whitespace-after": [ "always" ],
 
+		"number-leading-zero": [ "always" ],
+		"number-no-trailing-zeros": true,
+		"number-zero-length-no-unit": true,
+
 		"value-list-comma-newline-after": [ "never-multi-line" ],
 		"value-list-comma-newline-before": [ "always-multi-line" ],
 		"value-list-comma-space-after": [ "always-single-line" ],


### PR DESCRIPTION
Per CSS coding conventions:
OK:
* 0
* 30px
* 2.2em
* 0.5rem

Bad:
* .3px
* 0em
* 0.20rem

Fixes #1.