### PR TITLE
Fix `value-list-comma-newline-before`

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
 		"function-whitespace-after": [ "always" ],
 
 		"value-list-comma-newline-after": [ "never-multi-line" ],
-		"value-list-comma-newline-before": [ "always-multi-line" ],
+		"value-list-comma-newline-before": [ "never-multi-line" ],
 		"value-list-comma-space-after": [ "always-single-line" ],
 		"value-list-comma-space-before": [ "never" ],
 


### PR DESCRIPTION
Fixing `value-list-comma-newline-before` to `never-multi-line` as well.