### PR TITLE
Set 'no-browser-hacks' and 'no-unsupported-browser-features' rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,46 @@ module.exports = {
 		"declaration-no-important": true,
 		"selector-no-id": true,
 
+		"no-browser-hacks": [ true, {
+			"browsers": [
+				">0.1%",
+				"last 2 Chrome versions",
+				"last 2 ChromeAndroid versions",
+				"Explorer >= 6",
+				"ExplorerMobile >= 6",
+				"Edge >= 12",
+				"Firefox >= 3",
+				"FirefoxAndroid >= 3",
+				"Safari >= 3",
+				"Opera >= 10",
+				"OperaMobile >= 10",
+				"iOS >= 6.1",
+				"Android >= 2.3",
+				"not BlackBerry >= 1",
+				"not OperaMini >= 1",
+			]
+		} ],
+
+		"no-unsupported-browser-features": [ true, {
+			"browsers": [
+				">5%",
+				"last 2 Chrome versions",
+				"last 2 ChromeAndroid versions",
+				"Explorer >= 9",
+				"ExplorerMobile >= 9",
+				"Edge >= 12",
+				"last 2 Firefox versions",
+				"last 2 FirefoxAndroid versions",
+				"Safari >= 5.1",
+				"Opera >= 12.1",
+				"OperaMobile >= 12",
+				"iOS >= 6.1",
+				"Android >= 2.3",
+				"not BlackBerry >= 1",
+				"not OperaMini >= 1",
+			]
+		} ],
+
 		"no-unknown-animations": true,
 
 		"color-hex-case": [ "lower" ],


### PR DESCRIPTION
These are taken from the shared Wikimedia browser support matrix at
https://www.mediawiki.org/wiki/Compatibility#Browser_support_matrix and
will likely fail in several projects; where failures arise, I would
anticipate that the uses are considered and either commented to allow
or altered — this isn't a general prohibition, especially for areas of
graceful degredation.

The 'no-browser-hacks' rule is aimed at replicating "Grade C" coverage,
and results in 138 browser/version combinations:

``` js
[ 'and_chr 50',
'and_ff 46',
'and_uc 9.9',
'android 50',
'android 4.4.3-4.4.4',
'android 4.4',
'android 4.2-4.3',
'android 4.1',
'android 4',
'android 3',
'android 2.3',
'chrome 51',
'chrome 50',
'chrome 49',
'chrome 48',
'chrome 47',
'chrome 46',
'chrome 45',
'chrome 44',
'chrome 43',
'chrome 42',
'chrome 41',
'chrome 39',
'chrome 31',
'chrome 29',
'edge 13',
'edge 12',
'firefox 46',
'firefox 45',
'firefox 44',
'firefox 43',
'firefox 42',
'firefox 41',
'firefox 40',
'firefox 39',
'firefox 38',
'firefox 37',
'firefox 36',
'firefox 35',
'firefox 34',
'firefox 33',
'firefox 32',
'firefox 31',
'firefox 30',
'firefox 29',
'firefox 28',
'firefox 27',
'firefox 26',
'firefox 25',
'firefox 24',
'firefox 23',
'firefox 22',
'firefox 21',
'firefox 20',
'firefox 19',
'firefox 18',
'firefox 17',
'firefox 16',
'firefox 15',
'firefox 14',
'firefox 13',
'firefox 12',
'firefox 11',
'firefox 10',
'firefox 9',
'firefox 8',
'firefox 7',
'firefox 6',
'firefox 5',
'firefox 4',
'firefox 3.6',
'firefox 3.5',
'firefox 3',
'ie 11',
'ie 10',
'ie 9',
'ie 8',
'ie 7',
'ie 6',
'ie_mob 11',
'ie_mob 10',
'ios_saf 9.3',
'ios_saf 9.0-9.2',
'ios_saf 8.1-8.4',
'ios_saf 8',
'ios_saf 7.0-7.1',
'ios_saf 6.0-6.1',
'op_mob 36',
'op_mob 12.1',
'op_mob 12',
'op_mob 11.5',
'op_mob 11.1',
'op_mob 11',
'op_mob 10',
'opera 37',
'opera 36',
'opera 35',
'opera 34',
'opera 33',
'opera 32',
'opera 31',
'opera 30',
'opera 29',
'opera 28',
'opera 27',
'opera 26',
'opera 25',
'opera 24',
'opera 23',
'opera 22',
'opera 21',
'opera 20',
'opera 19',
'opera 18',
'opera 17',
'opera 16',
'opera 15',
'opera 12.1',
'opera 12',
'opera 11.6',
'opera 11.5',
'opera 11.1',
'opera 11',
'opera 10.6',
'opera 10.5',
'opera 10.0-10.1',
'safari 9.1',
'safari 9',
'safari 8',
'safari 7.1',
'safari 7',
'safari 6.1',
'safari 6',
'safari 5.1',
'safari 5',
'safari 4',
'safari 3.2',
'safari 3.1' ]
```

The 'no-unsupported-browser-features' rule is aimed at replicating "Grade A"
coverage, and results in 'just' 63 browser/version combinations:

``` js
[ 'and_chr 50',
'and_ff 46',
'and_uc 9.9',
'android 50',
'android 4.4.3-4.4.4',
'android 4.4',
'android 4.2-4.3',
'android 4.1',
'android 4',
'android 3',
'android 2.3',
'chrome 50',
'chrome 49',
'edge 13',
'edge 12',
'firefox 46',
'firefox 45',
'ie 11',
'ie 10',
'ie 9',
'ie_mob 11',
'ie_mob 10',
'ios_saf 9.3',
'ios_saf 9.0-9.2',
'ios_saf 8.1-8.4',
'ios_saf 8',
'ios_saf 7.0-7.1',
'ios_saf 6.0-6.1',
'op_mob 36',
'op_mob 12.1',
'op_mob 12',
'opera 37',
'opera 36',
'opera 35',
'opera 34',
'opera 33',
'opera 32',
'opera 31',
'opera 30',
'opera 29',
'opera 28',
'opera 27',
'opera 26',
'opera 25',
'opera 24',
'opera 23',
'opera 22',
'opera 21',
'opera 20',
'opera 19',
'opera 18',
'opera 17',
'opera 16',
'opera 15',
'opera 12.1',
'safari 9.1',
'safari 9',
'safari 8',
'safari 7.1',
'safari 7',
'safari 6.1',
'safari 6',
'safari 5.1' ]
```

Fixes #14.
