### PR TITLE
Tag v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
 
+## 0.2.0 / 2016-05-23
+* New rule: `number-leading-zero`, configured as 'always' (James D. Forrester)
+* New rule: `number-no-trailing-zeros`, configured as 'true' (James D. Forrester)
+* New rule: `number-zero-length-no-unit`, configured as 'true' (James D. Forrester)
+* New rule: `stylelint-value-border-zero` (via plugin), configured as '0' (Volker E)
+* Change rule: Set `selector-pseudo-element-colon-notation` to 'single', not 'double' (Ed Sanders)
+* Change rule: Set `value-list-comma-newline-before` to 'never-multi-line', not 'always-multi-line' (Volker E)
+* build: Provide a .jscsrc file for local JavaScript linting (James D. Forrester)
+
 ## 0.1.0 / 2016-05-17
-* Initial release.
+* Initial release (James Forrester)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-wikimedia",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Wikimedia shareable config for stylelint",
   "keywords": [
     "code",


### PR DESCRIPTION
Changes:

* New rule: `number-leading-zero`, configured as 'always' (James D. Forrester)
* New rule: `number-no-trailing-zeros`, configured as 'true' (James D. Forrester)
* New rule: `number-zero-length-no-unit`, configured as 'true' (James D. Forrester)
* New rule: `stylelint-value-border-zero` (via plugin), configured as '0' (Volker E.)
* Change rule: Set `selector-pseudo-element-colon-notation` to 'single', not 'double' (Ed Sanders)
* Change rule: Set `value-list-comma-newline-before` to 'never-multi-line', not 'always-multi-line' (Volker E.)
* build: Provide a .jscsrc file for local JavaScript linting (James D. Forrester)