### PR TITLE
Add outline to property value blacklist

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ module.exports = {
 		"at-rule-no-unknown": true,
 
 		"declaration-property-value-blacklist": {
-			"/^border/": [ "none" ]
+			"/^border/": [ "none" ],
+			"/^outline/": [ "none" ]
 		}
 	}
 };


### PR DESCRIPTION
Adding `outline: none` to declaration-property-value-blacklist.

Fixing #21