### PR TITLE
Update rule: `block-no-single-line` is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,9 @@ module.exports = {
 		"block-closing-brace-space-after": [ "always-single-line" ],
 		"block-closing-brace-space-before": [ "always-single-line" ],
 		"block-no-empty": true,
-		"block-no-single-line": true,
-		"block-opening-brace-newline-after": [ "always-multi-line" ],
+
+		"block-opening-brace-newline-after": [ "always" ],
+		"block-opening-brace-newline-before": [ "always" ],
 		"block-opening-brace-space-after": [ "always-single-line" ],
 		"block-opening-brace-space-before": [ "always" ],
 


### PR DESCRIPTION
Replaced instead with `block-closing-brace-newline-after` and `block-closing-brace-newline-before` set to "always" (previously "always-multi-line" and unset, respectively).

Part of #42.