### PR TITLE
Removed rule: `selector-root-no-composition` is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,11 +128,9 @@ module.exports = {
 		"selector-pseudo-class-parentheses-space-inside": [ "always" ],
 		"selector-pseudo-element-case": [ "lower" ],
 		"selector-pseudo-element-colon-notation": [ "single" ],
-		"selector-root-no-composition": true,
 		"selector-type-case": [ "lower" ],
 		"selector-type-no-unknown": true,
 		"selector-pseudo-element-colon-notation": [ "single" ],
-		"selector-root-no-composition": true,
 
 		"shorthand-property-no-redundant-values": true,
 


### PR DESCRIPTION
For some reason we had it twice.

Part of #42.