### PR TITLE
New rule: `comment-whitespace-inside`, set to `always`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
 		"color-no-invalid-hex": true,
 
 		"comment-no-empty": true,
+		"comment-whitespace-inside": "always",
 
 		"declaration-bang-space-after": [ "never" ],
 		"declaration-bang-space-before": [ "always" ],


### PR DESCRIPTION
Part of #3