### PR TITLE
New rule: `font-family-no-missing-generic-family-keyword`, set to `true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = {
 		},
 
 		"font-family-name-quotes": [ "always-unless-keyword" ],
+		"font-family-no-missing-generic-family-keyword": true,
 		"font-weight-notation": [ "named-where-possible" ],
 
 		"function-blacklist": [ "rgb" ],


### PR DESCRIPTION
…true`

Not setting a generic `font-family` can result in unintended layout
issues across platforms.

Part of #3