### PR TITLE
New rule: `selector-max-empty-lines`, set to `0`

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ module.exports = {
 		"selector-list-comma-space-after": [ "always-single-line" ],
 		"selector-list-comma-space-before": [ "never" ],
 
+		"selector-max-empty-lines": 0,
 		"selector-max-id": 0,
 		"selector-no-vendor-prefix": true,
 		"selector-pseudo-class-case": [ "lower" ],


### PR DESCRIPTION
Another missing rule, that is already part of our coding guidelines,
but hasn't been integrated into our stylelint config.