### PR TITLE
New rule 'rule-empty-line-before', set to 'always-multi-line'

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,13 @@ module.exports = {
 		"property-case": [ "lower" ],
 		"property-no-unknown": true,
 
+		"rule-empty-line-before": [
+			"always-multi-line", {
+				except: [ "first-nested" ],
+				ignore: [ "after-comment" ]
+			}
+		],
+
 		"selector-attribute-brackets-space-inside": [ "always" ],
 		"selector-attribute-operator-space-after": [ "never" ],
 		"selector-attribute-operator-space-before": [ "never" ],

--- a/index.js
+++ b/index.js
@@ -118,8 +118,8 @@ module.exports = {
 
 		"rule-empty-line-before": [
 			"always-multi-line", {
-				except: [ "first-nested" ],
-				ignore: [ "after-comment" ]
+				"except": [ "first-nested" ],
+				"ignore": [ "after-comment" ]
 			}
 		],
 


### PR DESCRIPTION
Adding exception for 'first-nested' and ignoring 'after-comment'.

Fixes #76