### PR TITLE
New rule: Add `rem` to `unit-blacklist`

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,7 @@ module.exports = {
 
 		"time-min-milliseconds": 100,
 
+		"unit-blacklist": "rem",
 		"unit-case": "lower",
 		"unit-no-unknown": true,
 


### PR DESCRIPTION
`rem` with our base font variety doesn't make sense in majority
of our current use cases and is most-often only added by
accident or lack of knowledge.

Fixes #94