### PR TITLE
Add "declaration-property-unit-blacklist" with `px` as error on `font…

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,12 @@ module.exports = {
 		} ],
 		"declaration-no-important": true,
 
+		// `px` values disable accessibility browser setting of user font overrides and 
+		// should be set in relative units like `em` or `rem` instead.
+		"declaration-property-unit-blacklist": { 
+			"font-size": "px",
+			"line-height": "px"
+		},
 		"declaration-property-value-blacklist": {
 			"/^border/": "none",
 			"/^outline/": "none"


### PR DESCRIPTION
…-size` and `line-height`

Adding "declaration-property-unit-blacklist" with values to prevent two of the most important accessibility failures.
As many other rules, this doesn't work on variables, therefore won't flag `px` unit values set on such occurrencies.

Fixes #104