### PR TITLE
CI: Switch IRC network to Libera.Chat

### DIFF
--- a/.github/workflows/irc.yml
+++ b/.github/workflows/irc.yml
@@ -10,6 +10,7 @@ jobs:
       uses: rectalogic/notify-irc@v1
       if: github.event_name == 'pull_request'
       with:
+        server: irc.libera.chat
         channel: "#wikimedia-editing"
         nickname: WikimediaGitHub
         message: |
@@ -19,6 +20,7 @@ jobs:
       uses: rectalogic/notify-irc@v1
       if: github.event_name == 'create' && github.event.ref_type == 'tag'
       with:
+        server: irc.libera.chat
         channel: "#wikimedia-editing"
         nickname: WikimediaGitHub
         message: |


### PR DESCRIPTION
We don't use Freenode any more.