### PR TITLE
Restore grade-a/c as deprecated aliases of support-modern/basic

### DIFF
--- a/grade-a.json
+++ b/grade-a.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./support-modern"
+}

--- a/grade-c.json
+++ b/grade-c.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./support-basic"
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
 		"CHANGELOG.md",
 		"LICENSE",
 		"index.js",
+		"grade-a.js",
+		"grade-c.js",
 		"support-modern.json",
 		"support-basic.json"
 	],


### PR DESCRIPTION
This avoids making the next release a breaking change.
