### PR TITLE
Add postcss-less as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# eslint cache file
+.eslintcache

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
 			"version": "0.12.0",
 			"license": "MIT",
 			"dependencies": {
+				"postcss-less": "5.0.0",
 				"stylelint": "14.2.0",
 				"stylelint-no-unsupported-browser-features": "5.0.2"
 			},
 			"devDependencies": {
-				"eslint-config-wikimedia": "0.21.0",
-				"postcss-less": "5.0.0"
+				"eslint-config-wikimedia": "0.21.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -2864,7 +2864,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-5.0.0.tgz",
 			"integrity": "sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A==",
-			"dev": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -6105,8 +6104,7 @@
 		"postcss-less": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-5.0.0.tgz",
-			"integrity": "sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A==",
-			"dev": true
+			"integrity": "sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A=="
 		},
 		"postcss-media-query-parser": {
 			"version": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2641,9 +2641,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -5949,9 +5949,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 		"support-basic.json"
 	],
 	"devDependencies": {
-		"eslint-config-wikimedia": "0.21.0",
-		"postcss-less": "5.0.0"
+		"eslint-config-wikimedia": "0.21.0"
 	},
 	"dependencies": {
+		"postcss-less": "5.0.0",
 		"stylelint": "14.2.0",
 		"stylelint-no-unsupported-browser-features": "5.0.2"
 	}


### PR DESCRIPTION
This is in response to stylelint 14 dropping it.

Fixes #153.