### PR TITLE
Add `outline` to ignored no-unsupported-browser-features rules

### DIFF
--- a/support-basic.js
+++ b/support-basic.js
@@ -10,6 +10,9 @@ module.exports = {
 		"plugin/no-unsupported-browser-features": [ true, {
 			"browsers": require( 'browserslist-config-wikimedia/basic' ),
 			"severity": "warning",
+			"ignore": [
+				"outline"
+			],
 			"ignorePartialSupport": true
 		} ]
 	}

--- a/support-modern.js
+++ b/support-modern.js
@@ -10,6 +10,9 @@ module.exports = {
 		"plugin/no-unsupported-browser-features": [ true, {
 			"browsers": require( 'browserslist-config-wikimedia/modern' ),
 			"severity": "warning",
+			"ignore": [
+				"outline"
+			],
 			"ignorePartialSupport": true
 		} ]
 	}


### PR DESCRIPTION
Seems overly verbose given the small subset of `outline` CSS feature
that might not have been supported.

Fixes #166