### PR TITLE
Extend stylelint-config-recommended

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 /* eslint quotes: ["error", "double"] */
 /* eslint quote-props: ["error", "always"] */
 module.exports = {
+	"extends": "stylelint-config-recommended",
 	"rules": {
 		// Wikimedia Foundation ♡ whitespace in its own special way
 		// See also https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS#Whitespace
@@ -22,7 +23,6 @@ module.exports = {
 		} ],
 		"at-rule-name-case": "lower",
 		"at-rule-name-space-after": "always-single-line",
-		"at-rule-no-unknown": true,
 		"at-rule-semicolon-newline-after": "always",
 
 		"block-closing-brace-empty-line-before": "never",
@@ -30,8 +30,6 @@ module.exports = {
 		"block-closing-brace-newline-before": "always-multi-line",
 		"block-closing-brace-space-after": "always-single-line",
 		"block-closing-brace-space-before": "always-single-line",
-
-		"block-no-empty": true,
 
 		"block-opening-brace-newline-after": "always",
 		"block-opening-brace-newline-before": "always-single-line",
@@ -41,20 +39,13 @@ module.exports = {
 		"color-hex-case": "lower",
 		"color-hex-length": "short",
 		"color-named": "never",
-		"color-no-invalid-hex": true,
 
-		"comment-no-empty": true,
 		"comment-whitespace-inside": "always",
 
 		"declaration-bang-space-after": "never",
 		"declaration-bang-space-before": "always",
 
-		"declaration-block-no-duplicate-properties": [ true, {
-			"ignore": "consecutive-duplicates"
-		} ],
 		"declaration-block-no-redundant-longhand-properties": true,
-		"declaration-block-no-shorthand-property-overrides": true,
-
 		"declaration-block-semicolon-newline-after": "always",
 		"declaration-block-semicolon-newline-before": "never-multi-line",
 		"declaration-block-semicolon-space-after": "always-single-line",
@@ -84,16 +75,13 @@ module.exports = {
 		},
 
 		"font-family-name-quotes": "always-unless-keyword",
-		"font-family-no-missing-generic-family-keyword": true,
 		"font-weight-notation": "named-where-possible",
 
 		"function-disallowed-list": "rgb",
-		"function-calc-no-unspaced-operator": true,
 		"function-comma-newline-after": "never-multi-line",
 		"function-comma-newline-before": "never-multi-line",
 		"function-comma-space-after": "always",
 		"function-comma-space-before": "never",
-		"function-linear-gradient-no-nonstandard-direction": true,
 		"function-max-empty-lines": 0,
 		"function-name-case": [ "lower", {
 			"ignoreFunctions": "/^DXImageTransform.Microsoft.*$/"
@@ -110,7 +98,6 @@ module.exports = {
 		"media-feature-colon-space-after": "always",
 		"media-feature-colon-space-before": "never",
 		"media-feature-name-case": "lower",
-		"media-feature-name-no-unknown": true,
 		"media-feature-name-no-vendor-prefix": null,
 		"media-feature-parentheses-space-inside": "always",
 		"media-feature-range-operator-space-after": "always",
@@ -121,17 +108,12 @@ module.exports = {
 		"media-query-list-comma-space-after": "always-single-line",
 		"media-query-list-comma-space-before": "never",
 
-		"no-descending-specificity": true,
-		"no-duplicate-selectors": true,
-		"no-invalid-double-slash-comments": true,
-		"no-extra-semicolons": true,
 		"no-unknown-animations": true,
 
 		"number-leading-zero": "always",
 		"number-no-trailing-zeros": true,
 
 		"property-case": "lower",
-		"property-no-unknown": true,
 
 		"rule-empty-line-before": [
 			"always-multi-line", {
@@ -157,21 +139,18 @@ module.exports = {
 		"selector-max-id": 0,
 		"selector-no-vendor-prefix": true,
 		"selector-pseudo-class-case": "lower",
-		"selector-pseudo-class-no-unknown": true,
 		"selector-pseudo-class-parentheses-space-inside": "always",
 		"selector-pseudo-element-case": "lower",
 		"selector-pseudo-element-colon-notation": "single",
 		"selector-type-case": "lower",
 		"selector-type-no-unknown": true,
 
-		"string-no-newline": true,
 		"string-quotes": "single",
 
 		"time-min-milliseconds": 100,
 
 		"unit-disallowed-list": "rem",
 		"unit-case": "lower",
-		"unit-no-unknown": true,
 
 		"value-keyword-case": "lower",
 		"value-list-max-empty-lines": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"browserslist-config-wikimedia": "0.4.0",
 				"postcss-less": "6.0.0",
 				"stylelint": "14.2.0",
+				"stylelint-config-recommended": "6.0.0",
 				"stylelint-no-unsupported-browser-features": "5.0.3"
 			},
 			"devDependencies": {
@@ -3087,6 +3088,14 @@
 				"url": "https://opencollective.com/stylelint"
 			}
 		},
+		"node_modules/stylelint-config-recommended": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"peerDependencies": {
+				"stylelint": "^14.0.0"
+			}
+		},
 		"node_modules/stylelint-no-unsupported-browser-features": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-5.0.3.tgz",
@@ -5743,6 +5752,12 @@
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 				}
 			}
+		},
+		"stylelint-config-recommended": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"requires": {}
 		},
 		"stylelint-no-unsupported-browser-features": {
 			"version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"browserslist-config-wikimedia": "0.4.0",
 		"postcss-less": "6.0.0",
 		"stylelint": "14.2.0",
+		"stylelint-config-recommended": "6.0.0",
 		"stylelint-no-unsupported-browser-features": "5.0.3"
 	},
 	"peerDependencies": {

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -1,3 +1,6 @@
+/* We can't test no-empty-source */
+/* skip-stylelint-disable no-empty-source */
+
 div {
 	/* stylelint-disable-next-line indentation */
     width: 1px;
@@ -19,8 +22,8 @@ div {
 	color: #fff;
 }
 
-/* stylelint-disable-next-line at-rule-semicolon-newline-after */
-@import url( x.css ); @import url( y.css );
+/* stylelint-disable-next-line at-rule-semicolon-newline-after, no-invalid-position-at-import-rule, no-duplicate-at-import-rules */
+@import url( x.css ); @import url( x.css );
 
 span {
 	color: #fff;
@@ -50,12 +53,21 @@ span {
 /* stylelint-disable-next-line comment-no-empty, comment-whitespace-inside */
 /**/
 
+:root {
+	--foo: #fff;
+}
+
 .e {
+	/* stylelint-disable-next-line custom-property-no-missing-var-function */
+	color: --foo;
 	/* stylelint-disable-next-line declaration-bang-space-after, declaration-bang-space-before, declaration-no-important */
 	color: #fff! important;
 	background: #fff;
 	/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 	color: #fff;
+	--custom-property: #fff;
+	/* stylelint-disable-next-line declaration-block-no-duplicate-custom-properties */
+	--custom-property: #fff;
 }
 
 .f {
@@ -94,8 +106,8 @@ span {
 	border: none;
 	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 	outline: none;
-	/* stylelint-disable-next-line font-family-name-quotes, font-family-no-missing-generic-family-keyword */
-	font-family: Times New Roman;
+	/* stylelint-disable-next-line font-family-name-quotes, font-family-no-duplicate-names, font-family-no-missing-generic-family-keyword */
+	font-family: Times New Roman, Times New Roman;
 	/* stylelint-disable-next-line font-weight-notation */
 	font-weight: 400;
 	/* stylelint-disable-next-line function-disallowed-list */
@@ -117,6 +129,17 @@ span {
 	transform: translate( 1, 1 )scale( 3 );
 	/* stylelint-disable-next-line length-zero-no-unit */
 	top: 0px;
+}
+
+@keyframes fade {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		/* stylelint-disable-next-line keyframe-declaration-no-important, declaration-no-important */
+		opacity: 1 !important;
+	}
 }
 
 /* stylelint-disable-next-line media-feature-colon-space-after, media-feature-colon-space-before, media-feature-name-case, media-feature-parentheses-space-inside */
@@ -145,6 +168,12 @@ span {
 }
 
 .a .k {
+	/* stylelint-disable-next-line named-grid-areas-no-invalid */
+	grid-template-areas: '';
+}
+
+/* stylelint-disable-next-line no-irregular-whitespace */
+.nb .sp {
 	/* ... */
 }
 
@@ -190,8 +219,8 @@ span {
 	/* ... */
 }
 
-/* stylelint-disable-next-line selector-pseudo-class-case, selector-pseudo-class-no-unknown, selector-pseudo-class-parentheses-space-inside, selector-pseudo-element-case, selector-pseudo-element-colon-notation */
-.t:HOVER:unknown:not(.a)::BEFORE {
+/* stylelint-disable-next-line selector-pseudo-class-case, selector-pseudo-class-no-unknown, selector-pseudo-class-parentheses-space-inside, selector-pseudo-element-case, selector-pseudo-element-colon-notation, selector-pseudo-element-no-unknown */
+.t:HOVER:unknown:not(.a)::BEFORE::pseudo {
 	/* ... */
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,7 @@ QUnit.module( 'default config', () => {
 			Object.keys( rules ).forEach( ( rule ) => {
 				// Disabled rules are covered below.
 				if ( isEnabled( rule ) ) {
-					const rDisableRule = new RegExp( `(/[/*]|<!--|#) stylelint-disable((-next)?-line)? ([a-z-/]+, ?)*?${rule}($|[^a-z-])` );
+					const rDisableRule = new RegExp( `(/[/*]|<!--|#) (skip-)?stylelint-disable((-next)?-line)? ([a-z-/]+, ?)*?${rule}($|[^a-z-])` );
 					assert.true( rDisableRule.test( invalidFixtures ), `Rule '${rule}' is covered in invalid fixture` );
 				}
 			} );


### PR DESCRIPTION
Introduces the following rules:
* custom-property-no-missing-var-function
* declaration-block-no-duplicate-custom-properties
* font-family-no-duplicate-names
* keyframe-declaration-no-important
* named-grid-areas-no-invalid
* no-duplicate-at-import-rules
* no-empty-source
* no-invalid-position-at-import-rule
* no-irregular-whitespace
* selector-pseudo-element-no-unknown

Remove rules which are duplicated upstream

declaration-block-no-duplicate-properties is changed slightly
from ignore:consecutive-duplicates to
ignore:consecutive-duplicates-with-different-values.

Fixes #173