### PR TITLE
Update Stylelint and stylelint-config-recommended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"browserslist-config-wikimedia": "0.4.0",
 				"postcss-less": "6.0.0",
-				"stylelint": "14.2.0",
+				"stylelint": "14.8.1",
 				"stylelint-config-recommended": "6.0.0",
 				"stylelint-no-unsupported-browser-features": "5.0.3"
 			},
@@ -610,6 +610,14 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-functions-list": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+			"integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
+			"engines": {
+				"node": ">=12.22"
+			}
+		},
 		"node_modules/css-rule-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
@@ -665,9 +673,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1707,7 +1715,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1718,11 +1725,14 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
 		},
 		"node_modules/html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ignore": {
@@ -1877,11 +1887,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"node_modules/isarray": {
 			"version": "0.0.1",
@@ -2134,12 +2139,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
@@ -2209,9 +2214,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.0.tgz",
-			"integrity": "sha512-JzxqqT5u/x+/KOFSd7JP15DOo9nOoHpx6DYatqIHUW2+flybkm+mdcraotSQR5WcnZr+qhGVh8Ted0KdfSMxlg==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+			"integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2426,20 +2431,26 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-			"integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+			"version": "8.4.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				}
+			],
 			"dependencies": {
-				"nanoid": "^3.2.0",
+				"nanoid": "^3.3.1",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/postcss-less": {
@@ -2479,9 +2490,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3033,23 +3044,24 @@
 			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
 		},
 		"node_modules/stylelint": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz",
-			"integrity": "sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==",
+			"version": "14.8.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.8.1.tgz",
+			"integrity": "sha512-0YxTop3wTeEVmQWhS7jjLFaBkvfPmffRiJ6eFIDlK++f3OklaobTYFJu32E5u/cIrFLbcW52pLqrYpihA/y0/w==",
 			"dependencies": {
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.2",
 				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.3",
+				"css-functions-list": "^3.0.1",
+				"debug": "^4.3.4",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.7",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.4",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
+				"html-tags": "^3.2.0",
 				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
@@ -3057,25 +3069,26 @@
 				"known-css-properties": "^0.24.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
+				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
+				"postcss": "^8.4.12",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.7",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"specificity": "^0.4.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.7.5",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"bin": {
 				"stylelint": "bin/stylelint.js"
@@ -3129,9 +3142,20 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -3276,14 +3300,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
-			}
-		},
 		"node_modules/upath": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
@@ -3391,14 +3407,15 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
+				"signal-exit": "^3.0.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/xtend": {
@@ -3930,6 +3947,11 @@
 				"which": "^2.0.1"
 			}
 		},
+		"css-functions-list": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+			"integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw=="
+		},
 		"css-rule-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
@@ -3978,9 +4000,9 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -4741,8 +4763,7 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"hosted-git-info": {
 			"version": "2.8.9",
@@ -4750,9 +4771,9 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
 		},
 		"html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg=="
 		},
 		"ignore": {
 			"version": "5.2.0",
@@ -4861,11 +4882,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
 			"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA=="
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -5070,12 +5086,12 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"min-indent": {
@@ -5126,9 +5142,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.0.tgz",
-			"integrity": "sha512-JzxqqT5u/x+/KOFSd7JP15DOo9nOoHpx6DYatqIHUW2+flybkm+mdcraotSQR5WcnZr+qhGVh8Ted0KdfSMxlg=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+			"integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -5282,11 +5298,11 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-			"integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+			"version": "8.4.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
 			"requires": {
-				"nanoid": "^3.2.0",
+				"nanoid": "^3.3.1",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -5314,9 +5330,9 @@
 			"requires": {}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -5696,23 +5712,24 @@
 			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
 		},
 		"stylelint": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz",
-			"integrity": "sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==",
+			"version": "14.8.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.8.1.tgz",
+			"integrity": "sha512-0YxTop3wTeEVmQWhS7jjLFaBkvfPmffRiJ6eFIDlK++f3OklaobTYFJu32E5u/cIrFLbcW52pLqrYpihA/y0/w==",
 			"requires": {
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.2",
 				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.3",
+				"css-functions-list": "^3.0.1",
+				"debug": "^4.3.4",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.7",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.4",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
+				"html-tags": "^3.2.0",
 				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
@@ -5720,25 +5737,26 @@
 				"known-css-properties": "^0.24.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
+				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
+				"postcss": "^8.4.12",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.7",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"specificity": "^0.4.1",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.7.5",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -5773,9 +5791,17 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			}
 		},
 		"supports-preserve-symlinks-flag": {
@@ -5890,14 +5916,6 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"requires": {
-				"is-typedarray": "^1.0.0"
-			}
-		},
 		"upath": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
@@ -5977,14 +5995,12 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
 			"requires": {
 				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
+				"signal-exit": "^3.0.7"
 			}
 		},
 		"xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"browserslist-config-wikimedia": "0.4.0",
 				"postcss-less": "6.0.0",
 				"stylelint": "14.8.1",
-				"stylelint-config-recommended": "6.0.0",
+				"stylelint-config-recommended": "7.0.0",
 				"stylelint-no-unsupported-browser-features": "5.0.3"
 			},
 			"devDependencies": {
@@ -3102,11 +3102,11 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+			"integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
 			"peerDependencies": {
-				"stylelint": "^14.0.0"
+				"stylelint": "^14.4.0"
 			}
 		},
 		"node_modules/stylelint-no-unsupported-browser-features": {
@@ -5772,9 +5772,9 @@
 			}
 		},
 		"stylelint-config-recommended": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+			"integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
 			"requires": {}
 		},
 		"stylelint-no-unsupported-browser-features": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"browserslist-config-wikimedia": "0.4.0",
 		"postcss-less": "6.0.0",
 		"stylelint": "14.8.1",
-		"stylelint-config-recommended": "6.0.0",
+		"stylelint-config-recommended": "7.0.0",
 		"stylelint-no-unsupported-browser-features": "5.0.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	"dependencies": {
 		"browserslist-config-wikimedia": "0.4.0",
 		"postcss-less": "6.0.0",
-		"stylelint": "14.2.0",
+		"stylelint": "14.8.1",
 		"stylelint-config-recommended": "6.0.0",
 		"stylelint-no-unsupported-browser-features": "5.0.3"
 	},

--- a/support-basic.js
+++ b/support-basic.js
@@ -11,6 +11,9 @@ module.exports = {
 			"browsers": require( 'browserslist-config-wikimedia/basic' ),
 			"severity": "warning",
 			"ignorePartialSupport": true
-		} ]
+		} ],
+		// Must remain enabled as long as some of our "basic" browsers don't support https://caniuse.com/css-not-sel-list
+		"selector-not-notation": "simple"
+
 	}
 };

--- a/support-modern.js
+++ b/support-modern.js
@@ -11,6 +11,8 @@ module.exports = {
 			"browsers": require( 'browserslist-config-wikimedia/modern' ),
 			"severity": "warning",
 			"ignorePartialSupport": true
-		} ]
+		} ],
+		// Must remain enabled as long as some of our "modern" browsers don't support https://caniuse.com/css-not-sel-list
+		"selector-not-notation": "simple"
 	}
 };

--- a/test/fixtures/basic/invalid.css
+++ b/test/fixtures/basic/invalid.css
@@ -3,3 +3,8 @@ div {
 	/* stylelint-disable-next-line plugin/no-unsupported-browser-features */
 	position: sticky;
 }
+
+/* stylelint-disable-next-line selector-not-notation */
+div:not( .a, .b ) {
+	/* ... */
+}

--- a/test/fixtures/basic/valid.css
+++ b/test/fixtures/basic/valid.css
@@ -1,0 +1,5 @@
+/* Valid: selector-not-notation */
+div:not( .a ),
+div:not( .b ) {
+	/* ... */
+}

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -118,6 +118,8 @@ span {
 	transform: translate(1 ,
 
 	1 ); /* stylelint-disable-line function-parentheses-newline-inside */
+	/* stylelint-disable-next-line function-no-unknown */
+	transform: something( 2 );
 }
 
 .k {

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -152,7 +152,7 @@ span {
 	/* ... */
 }
 
-/* stylelint-disable-next-line media-feature-range-operator-space-after, media-feature-range-operator-space-before */
+/* stylelint-disable-next-line media-feature-range-operator-space-after, media-feature-range-operator-space-before, media-feature-name-no-unknown */
 @media ( width>=600px ) {
 	/* ... */
 }

--- a/test/fixtures/modern/invalid.css
+++ b/test/fixtures/modern/invalid.css
@@ -5,3 +5,8 @@ div {
 	/* stylelint-disable-next-line plugin/no-unsupported-browser-features */
 	position: sticky;
 }
+
+/* stylelint-disable-next-line selector-not-notation */
+div:not( .a, .b ) {
+	/* ... */
+}

--- a/test/fixtures/modern/valid.css
+++ b/test/fixtures/modern/valid.css
@@ -1,0 +1,5 @@
+/* Valid: selector-not-notation */
+div:not( .a ),
+div:not( .b ) {
+	/* ... */
+}


### PR DESCRIPTION
- Update Stylelint to 14.8.1
- Update stylelint-config-recommended to 7.0.0
- Basic/modern: Set `selector-not-notation` to `simple`