### PR TITLE
mediawiki config and selector-class-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ If you would also like to enable rules to disallow CSS which is unsupported by m
 }
 ```
 
+If you are using in a MediaWiki environment, you can use add the following config:
+
+```json
+{
+	"extends": [
+		"stylelint-config-wikimedia",
+		"stylelint-config-wikimedia/mediawiki"
+	]
+}
+```
+
+If you need to combine this with browser support rules:
+
+```json
+{
+	"extends": [
+		"stylelint-config-wikimedia/support-modern",
+		"stylelint-config-wikimedia/mediawiki"
+	]
+}
+```
 
 ### Extend or override the configuration
 Add a `"rules"` object to your config file, and add your overrides or additional rules there, for example:

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 /* eslint quote-props: ["error", "always"] */
 module.exports = {
 	"extends": "stylelint-config-recommended",
-	"plugins": "./rules/no-at-import-css.js",
 	"rules": {
 		// Wikimedia Foundation ♡ whitespace in its own special way
 		// See also https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS#Whitespace
@@ -15,8 +14,6 @@ module.exports = {
 		"no-missing-end-of-source-newline": true,
 
 		// Other rules alphabetically
-		// MediaWiki will only support import in LESS files
-		"at-rule-disallowed-list": "import",
 		"at-rule-empty-line-before": [ "always", {
 			"except": [
 				"blockless-after-blockless",
@@ -164,17 +161,5 @@ module.exports = {
 		"value-list-comma-newline-before": "never-multi-line",
 		"value-list-comma-space-after": "always-single-line",
 		"value-list-comma-space-before": "never"
-	},
-	"overrides": [ {
-		"files": [ "**/*.less" ],
-		"customSyntax": "postcss-less",
-		"rules": {
-			// MediaWiki will only support @import in LESS files
-			"at-rule-disallowed-list": null,
-			// LESS imports can go anywhere
-			"no-invalid-position-at-import-rule": null,
-			// Don't allow CSS imports
-			"wikimedia/no-at-import-css": true
-		}
-	} ]
+	}
 };

--- a/mediawiki.js
+++ b/mediawiki.js
@@ -5,7 +5,9 @@ module.exports = {
 	"plugins": "./rules/no-at-import-css.js",
 	"rules": {
 		// MediaWiki will only support import in LESS files
-		"at-rule-disallowed-list": "import"
+		"at-rule-disallowed-list": "import",
+		// See https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS
+		"selector-class-pattern": "(ext|mw|oo-ui|cdx|client|skin)-"
 	},
 	"overrides": [ {
 		"files": [ "**/*.less" ],

--- a/mediawiki.js
+++ b/mediawiki.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/* eslint-disable quotes, quote-props */
+module.exports = {
+	"plugins": "./rules/no-at-import-css.js",
+	"rules": {
+		// MediaWiki will only support import in LESS files
+		"at-rule-disallowed-list": "import"
+	},
+	"overrides": [ {
+		"files": [ "**/*.less" ],
+		"customSyntax": "postcss-less",
+		"rules": {
+			// MediaWiki will only support @import in LESS files
+			"at-rule-disallowed-list": null,
+			// LESS imports can go anywhere
+			"no-invalid-position-at-import-rule": null,
+			// Don't allow CSS imports
+			"wikimedia/no-at-import-css": true
+		}
+	} ]
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"CHANGELOG.md",
 		"LICENSE",
 		"index.js",
+		"mediawiki.js",
 		"grade-a.json",
 		"grade-c.json",
 		"support-modern.js",

--- a/support-basic.js
+++ b/support-basic.js
@@ -14,6 +14,5 @@ module.exports = {
 		} ],
 		// Must remain enabled as long as some of our "basic" browsers don't support https://caniuse.com/css-not-sel-list
 		"selector-not-notation": "simple"
-
 	}
 };

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -22,7 +22,7 @@ div {
 	color: #fff;
 }
 
-/* stylelint-disable-next-line at-rule-disallowed-list, at-rule-semicolon-newline-after, no-invalid-position-at-import-rule, no-duplicate-at-import-rules */
+/* stylelint-disable-next-line at-rule-semicolon-newline-after, no-invalid-position-at-import-rule, no-duplicate-at-import-rules */
 @import url( x.css ); @import url( x.css );
 
 span {

--- a/test/fixtures/mediawiki/.stylelintrc.json
+++ b/test/fixtures/mediawiki/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../../../mediawiki"
+}

--- a/test/fixtures/mediawiki/invalid.css
+++ b/test/fixtures/mediawiki/invalid.css
@@ -1,0 +1,2 @@
+/* stylelint-disable-next-line at-rule-disallowed-list */
+@import url( foo.css );

--- a/test/fixtures/mediawiki/invalid.css
+++ b/test/fixtures/mediawiki/invalid.css
@@ -1,2 +1,7 @@
 /* stylelint-disable-next-line at-rule-disallowed-list */
 @import url( foo.css );
+
+/* stylelint-disable-next-line selector-class-pattern */
+.generic-name {
+	width: 1px;
+}

--- a/test/fixtures/mediawiki/invalid.less
+++ b/test/fixtures/mediawiki/invalid.less
@@ -1,6 +1,6 @@
 // stylelint-disable-next-line wikimedia/no-at-import-css
 @import 'foo.css';
-// stylelint-disable-next-line wikimedia/no-at-import-css, string-quotes
+// stylelint-disable-next-line wikimedia/no-at-import-css
 @import "bar.css";
 // stylelint-disable-next-line wikimedia/no-at-import-css
 @import baz.css;

--- a/test/fixtures/mediawiki/valid.css
+++ b/test/fixtures/mediawiki/valid.css
@@ -1,0 +1,9 @@
+/* Valid: selector-class-pattern */
+.ext-foo-name,
+.mw-bar-thing,
+.oo-ui-buttonElement,
+.cdx-widget,
+.client-js,
+.skin-vector {
+	width: 1px;
+}

--- a/test/fixtures/mediawiki/valid.less
+++ b/test/fixtures/mediawiki/valid.less
@@ -2,7 +2,7 @@ div {
 	width: 1px;
 }
 
-// Valid: no-invalid-position-at-import-rule
+// Valid: no-invalid-position-at-import-rule, at-rule-disallowed-list
 @import 'importAfterRule.less';
 
 // Valid: wikimedia/no-at-import-css


### PR DESCRIPTION
* Introduce `mediawiki` config
* New rule: `selector-class-pattern`, to prevent use of overly-generic class names without prefixes

Fixes #182, #86