### PR TITLE
Support modern/basic: Remove grade-a/c deprecated aliases

### DIFF
--- a/grade-a.json
+++ b/grade-a.json
@@ -1,3 +1,0 @@
-{
-	"extends": "./support-modern"
-}

--- a/grade-c.json
+++ b/grade-c.json
@@ -1,3 +1,0 @@
-{
-	"extends": "./support-basic"
-}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
 		"LICENSE",
 		"index.js",
 		"mediawiki.js",
-		"grade-a.json",
-		"grade-c.json",
 		"support-modern.json",
 		"support-basic.json",
 		"support-modern-rules.js",


### PR DESCRIPTION
These were deprecated in 0.11.0.
