### PR TITLE
Move `no-invalid-position-at-import-rule` from mediawiki to index

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,9 @@ module.exports = {
 		"customSyntax": "postcss-less",
 		"rules": {
 			// LESS functions are not supported by this rule
-			"function-no-unknown": null
+			"function-no-unknown": null,
+			// LESS imports can go anywhere
+			"no-invalid-position-at-import-rule": null
 		}
 	} ]
 };

--- a/mediawiki.js
+++ b/mediawiki.js
@@ -15,8 +15,6 @@ module.exports = {
 		"rules": {
 			// MediaWiki will only support @import in LESS files
 			"at-rule-disallowed-list": null,
-			// LESS imports can go anywhere
-			"no-invalid-position-at-import-rule": null,
 			// Don't allow CSS imports
 			"wikimedia/no-at-import-css": true
 		}

--- a/test/fixtures/default/valid.less
+++ b/test/fixtures/default/valid.less
@@ -2,3 +2,6 @@ div {
 	// Valid: function-no-unknown
 	color: lighten( #fc0, 50% );
 }
+
+// Valid: no-invalid-position-at-import-rule
+@import 'importAfterRule.less';

--- a/test/fixtures/mediawiki/valid.less
+++ b/test/fixtures/mediawiki/valid.less
@@ -2,7 +2,7 @@ div {
 	width: 1px;
 }
 
-// Valid: no-invalid-position-at-import-rule, at-rule-disallowed-list
+// Valid: at-rule-disallowed-list
 @import 'importAfterRule.less';
 
 // Valid: wikimedia/no-at-import-css


### PR DESCRIPTION
Any environment using LESS, not just MediaWiki environments, will
allow @import anywhere in the file.
