### PR TITLE
Rule fix: Handle (inline) properly in `no-at-import-css`

### DIFF
--- a/rules/no-at-import-css.js
+++ b/rules/no-at-import-css.js
@@ -52,13 +52,10 @@ module.exports = stylelint.createPlugin(
 				// The (less) keyword can be used to override the above rules.
 				if (
 					path.extname( filename ).toLowerCase() === '.css' &&
-					!( atRule.options && atRule.options.includes( 'less' ) )
+					!( atRule.options && atRule.options.includes( 'less' ) ) &&
+					!( atRule.options && atRule.options.includes( 'inline' ) )
 				) {
 					message = 'Files with a .css extension are not handled by LESS.';
-				}
-
-				if ( atRule.options && atRule.options.includes( 'inline' ) ) {
-					message = '@import with the (inline) keyword is not handled by LESS.';
 				}
 
 				if ( !message ) {

--- a/test/fixtures/mediawiki/invalid.less
+++ b/test/fixtures/mediawiki/invalid.less
@@ -4,5 +4,3 @@
 @import "bar.css";
 // stylelint-disable-next-line wikimedia/no-at-import-css
 @import baz.css;
-// stylelint-disable-next-line wikimedia/no-at-import-css
-@import (inline) bar.less;

--- a/test/fixtures/mediawiki/valid.less
+++ b/test/fixtures/mediawiki/valid.less
@@ -8,3 +8,4 @@ div {
 // Valid: wikimedia/no-at-import-css
 @import (less) foo.css;
 @import 'bar.less';
+@import (inline) baz.css;


### PR DESCRIPTION
This option does not tell LESS not to handle the import, it tells
LESS to inline the whole file verbatim when importing. It allows
CSS files to be imported by the LESS processor, and should be
considered valid.
