### PR TITLE
Changed rule: `selector-pseudo-element-colon-notation`: Expect double colon notation not single

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ module.exports = {
 		"selector-pseudo-class-case": "lower",
 		"selector-pseudo-class-parentheses-space-inside": "always",
 		"selector-pseudo-element-case": "lower",
-		"selector-pseudo-element-colon-notation": "single",
+		"selector-pseudo-element-colon-notation": "double",
 		"selector-type-case": "lower",
 		"selector-type-no-unknown": true,
 

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -234,7 +234,7 @@ span {
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-case, selector-pseudo-class-no-unknown, selector-pseudo-class-parentheses-space-inside, selector-pseudo-element-case, selector-pseudo-element-colon-notation, selector-pseudo-element-no-unknown */
-.t:HOVER:unknown:not(.a)::BEFORE::pseudo {
+.t:HOVER:unknown:not(.a):BEFORE::pseudo {
 	/* ... */
 }
 


### PR DESCRIPTION
To follow CSS standard and not outdated browsers.

Fix #200