### PR TITLE
mediawiki: Allow @import in Less in .vue files too

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -14,7 +14,7 @@ module.exports = {
 			"files": [ "**/*.less" ],
 			"customSyntax": "postcss-less",
 			"rules": {
-			// MediaWiki will only support @import in LESS files
+				// MediaWiki will only support @import in LESS files
 				"at-rule-disallowed-list": null,
 				// Don't allow CSS imports
 				"wikimedia/no-at-import-css": true
@@ -22,7 +22,13 @@ module.exports = {
 		},
 		{
 			"files": [ "**/*.vue" ],
-			"customSyntax": "postcss-less"
+			"customSyntax": "postcss-less",
+			"rules": {
+				// MediaWiki will only support @import in LESS files
+				"at-rule-disallowed-list": null,
+				// Don't allow CSS imports
+				"wikimedia/no-at-import-css": true
+			}
 		},
 		{
 			"files": [ "**/*.vue" ],

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -6,5 +6,6 @@
 </script>
 
 <style>
-	/* This comment is here to prevent no-empty-source errors */
+	/* Off: at-rule-disallowed-list */
+	@import 'lookMaICanImportHere.less';
 </style>


### PR DESCRIPTION
at-rule-disallowed-list was forbidding all uses of @import in .vue files, even the ones that we want to allow.