### PR TITLE
Disallow styling of .page-* classes

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -7,7 +7,7 @@ module.exports = {
 		// MediaWiki will only support import in LESS files
 		"at-rule-disallowed-list": "import",
 		// See https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS
-		"selector-class-pattern": "^(ext|mw|oo-ui|cdx|client|skin)-"
+		"selector-class-pattern": "^(ext|mw|oo-ui|cdx|client|skin|page)-"
 	},
 	"overrides": [
 		{


### PR DESCRIPTION
Using the body class is rare but we should limit usages of classes within the body element.

Fixes: #212