### PR TITLE
Disallow all problematic values for `text-transform`, not just `capitalize`

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = {
 		"declaration-property-value-disallowed-list": {
 			"/^border/": "none",
 			"/^outline/": "none",
-			"text-transform": "capitalize"
+			"text-transform": [ "capitalize", "uppercase", "lowercase" ]
 		},
 
 		"font-family-name-quotes": "always-unless-keyword",

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -108,6 +108,10 @@ span {
 	outline: none;
 	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 	text-transform: capitalize;
+	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
+	text-transform: uppercase;
+	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
+	text-transform: lowercase;
 	/* stylelint-disable-next-line font-family-name-quotes, font-family-no-duplicate-names, font-family-no-missing-generic-family-keyword */
 	font-family: Times New Roman, Times New Roman;
 	/* stylelint-disable-next-line font-weight-notation */

--- a/test/fixtures/default/valid.css
+++ b/test/fixtures/default/valid.css
@@ -1,4 +1,7 @@
 div {
 	/* Valid: font-family-no-duplicate-names's ignoreFontFamilyNames option */
 	font-family: monospace, monospace;
+
+	/* Valid: declaration-property-value-disallowed-list's text-transform entry allows the 'none' value */
+	text-transform: none;
 }


### PR DESCRIPTION
Follows-up #211.

Fixes #210.