### PR TITLE
Dropped rule: `unit-disallowed-list`, allow `rem` units from now on.

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ module.exports = {
 
 		"time-min-milliseconds": 100,
 
-		"unit-disallowed-list": "rem",
 		"unit-case": "lower",
 
 		"value-keyword-case": "lower",

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -256,7 +256,7 @@ unknown {
 	b";
 	/* stylelint-disable-next-line time-min-milliseconds */
 	animation: 80ms;
-	/* stylelint-disable-next-line unit-disallowed-list, unit-case */
+	/* stylelint-disable-next-line unit-case */
 	top: 1REM;
 	/* stylelint-disable-next-line value-keyword-case */
 	display: BLOCK;


### PR DESCRIPTION
We no longer support browsers that don't understand rems at all.

Related to #98