### PR TITLE
Downgrade stylelint-no-unsupported-browser-features to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"postcss-less": "6.0.0",
 				"stylelint": "15.10.1",
 				"stylelint-config-recommended": "13.0.0",
-				"stylelint-no-unsupported-browser-features": "7.0.0",
+				"stylelint-no-unsupported-browser-features": "6.1.0",
 				"stylelint-stylistic": "0.4.3"
 			},
 			"devDependencies": {
@@ -634,16 +634,13 @@
 			}
 		},
 		"node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"dependencies": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
+				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/color-convert": {
@@ -732,6 +729,40 @@
 			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
 			"engines": {
 				"node": ">=12.22"
+			}
+		},
+		"node_modules/css-rule-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+			"integrity": "sha512-qiio/Zkr8I19jh/XuzEkK8OKDQRTrEYaRyIHy4Bwh/tPUe0w8GcQs7r6x24Yc9lT+FbnZFYULxEIXCmaymguUQ==",
+			"dependencies": {
+				"css-tokenize": "^1.0.1",
+				"duplexer2": "0.0.2",
+				"ldjson-stream": "^1.2.1",
+				"through2": "^0.6.3"
+			},
+			"bin": {
+				"css-rule-stream": "index.js"
+			}
+		},
+		"node_modules/css-rule-stream/node_modules/readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/css-rule-stream/node_modules/through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+			"dependencies": {
+				"readable-stream": ">=1.0.33-1 <1.1.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
 		"node_modules/css-tokenize": {
@@ -854,25 +885,26 @@
 			}
 		},
 		"node_modules/doiuse": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-6.0.2.tgz",
-			"integrity": "sha512-eBTs23NOX+EAYPr4RbCR6J4DRW/TML3uMo37y0X1whlkersDYFCk9HmCl09KX98cis22VKsV1QaxfVNauJ3NBw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-4.4.1.tgz",
+			"integrity": "sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==",
 			"dependencies": {
-				"browserslist": "^4.21.5",
-				"caniuse-lite": "^1.0.30001487",
-				"css-tokenize": "^1.0.1",
-				"duplexify": "^4.1.2",
+				"browserslist": "^4.16.1",
+				"caniuse-lite": "^1.0.30001179",
+				"css-rule-stream": "^1.1.0",
+				"duplexer2": "0.0.2",
 				"ldjson-stream": "^1.2.1",
 				"multimatch": "^5.0.0",
-				"postcss": "^8.4.21",
-				"source-map": "^0.7.4",
-				"yargs": "^17.7.1"
+				"postcss": "^8.2.4",
+				"source-map": "^0.7.3",
+				"through2": "^4.0.2",
+				"yargs": "^16.2.0"
 			},
 			"bin": {
-				"doiuse": "bin/cli.js"
+				"doiuse": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -926,36 +958,12 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
-		"node_modules/duplexify": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+		"node_modules/duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
 			"dependencies": {
-				"end-of-stream": "^1.4.1",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1",
-				"stream-shift": "^1.0.0"
-			}
-		},
-		"node_modules/duplexify/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/duplexify/node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
+				"readable-stream": "~1.1.9"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -967,14 +975,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dependencies": {
-				"once": "^1.4.0"
-			}
 		},
 		"node_modules/entities": {
 			"version": "4.4.0",
@@ -2047,6 +2047,26 @@
 			"dependencies": {
 				"split2": "^0.2.1",
 				"through2": "^0.6.1"
+			}
+		},
+		"node_modules/ldjson-stream/node_modules/readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/ldjson-stream/node_modules/through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+			"dependencies": {
+				"readable-stream": ">=1.0.33-1 <1.1.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
 		"node_modules/levn": {
@@ -3131,10 +3151,25 @@
 				"through2": "~0.6.1"
 			}
 		},
-		"node_modules/stream-shift": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+		"node_modules/split2/node_modules/readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/split2/node_modules/through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+			"dependencies": {
+				"readable-stream": ">=1.0.33-1 <1.1.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
+			}
 		},
 		"node_modules/string_decoder": {
 			"version": "0.10.31",
@@ -3263,16 +3298,16 @@
 			}
 		},
 		"node_modules/stylelint-no-unsupported-browser-features": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-7.0.0.tgz",
-			"integrity": "sha512-O5VYlBhr+lpJ6jeTJSy+SMbHJhW5h5EJxsoicYcTi/07m45V/CF1mQidwRQLjv8y9BFQMpioWz60O89IkmbaNw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-6.1.0.tgz",
+			"integrity": "sha512-3Taj+z9PjIiY6cz4hg3eN8Khue3kMm9lPXYuEvdjAFXDK20uQo2NocJaWN6anIKclYlwrpkBAS9W/KV3qPTWsw==",
 			"dependencies": {
-				"doiuse": "^6.0.1",
+				"doiuse": "^4.4.1",
 				"lodash": "^4.17.15",
 				"postcss": "^8.4.16"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"stylelint": "^14.0.0||^15.0.0"
@@ -3388,23 +3423,32 @@
 			"dev": true
 		},
 		"node_modules/through2": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"dependencies": {
-				"readable-stream": ">=1.0.33-1 <1.1.0-0",
-				"xtend": ">=4.0.0 <4.1.0-0"
+				"readable-stream": "3"
 			}
 		},
 		"node_modules/through2/node_modules/readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/through2/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/tiny-glob": {
@@ -3650,20 +3694,20 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
 			"dependencies": {
-				"cliui": "^8.0.1",
+				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
+				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
+				"yargs-parser": "^20.2.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			}
 		},
 		"node_modules/yargs-parser": {
@@ -3672,14 +3716,6 @@
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yargs/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -4087,12 +4123,12 @@
 			}
 		},
 		"cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"requires": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
+				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
@@ -4162,6 +4198,39 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
 			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w=="
+		},
+		"css-rule-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+			"integrity": "sha512-qiio/Zkr8I19jh/XuzEkK8OKDQRTrEYaRyIHy4Bwh/tPUe0w8GcQs7r6x24Yc9lT+FbnZFYULxEIXCmaymguUQ==",
+			"requires": {
+				"css-tokenize": "^1.0.1",
+				"duplexer2": "0.0.2",
+				"ldjson-stream": "^1.2.1",
+				"through2": "^0.6.3"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
+			}
 		},
 		"css-tokenize": {
 			"version": "1.0.1",
@@ -4244,19 +4313,20 @@
 			}
 		},
 		"doiuse": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-6.0.2.tgz",
-			"integrity": "sha512-eBTs23NOX+EAYPr4RbCR6J4DRW/TML3uMo37y0X1whlkersDYFCk9HmCl09KX98cis22VKsV1QaxfVNauJ3NBw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-4.4.1.tgz",
+			"integrity": "sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==",
 			"requires": {
-				"browserslist": "^4.21.5",
-				"caniuse-lite": "^1.0.30001487",
-				"css-tokenize": "^1.0.1",
-				"duplexify": "^4.1.2",
+				"browserslist": "^4.16.1",
+				"caniuse-lite": "^1.0.30001179",
+				"css-rule-stream": "^1.1.0",
+				"duplexer2": "0.0.2",
 				"ldjson-stream": "^1.2.1",
 				"multimatch": "^5.0.0",
-				"postcss": "^8.4.21",
-				"source-map": "^0.7.4",
-				"yargs": "^17.7.1"
+				"postcss": "^8.2.4",
+				"source-map": "^0.7.3",
+				"through2": "^4.0.2",
+				"yargs": "^16.2.0"
 			}
 		},
 		"dom-serializer": {
@@ -4292,35 +4362,12 @@
 				"domhandler": "^5.0.1"
 			}
 		},
-		"duplexify": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
 			"requires": {
-				"end-of-stream": "^1.4.1",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1",
-				"stream-shift": "^1.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				}
+				"readable-stream": "~1.1.9"
 			}
 		},
 		"electron-to-chromium": {
@@ -4332,14 +4379,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"requires": {
-				"once": "^1.4.0"
-			}
 		},
 		"entities": {
 			"version": "4.4.0",
@@ -5128,6 +5167,28 @@
 			"requires": {
 				"split2": "^0.2.1",
 				"through2": "^0.6.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
 			}
 		},
 		"levn": {
@@ -5859,12 +5920,29 @@
 			"integrity": "sha512-D/oTExYAkC9nWleOCTOyNmAuzfAT/6rHGBA9LIK7FVnGo13CSvrKCUzKenwH6U1s2znY9MqH6v0UQTEDa3vJmg==",
 			"requires": {
 				"through2": "~0.6.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
 			}
-		},
-		"stream-shift": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"string_decoder": {
 			"version": "0.10.31",
@@ -5975,11 +6053,11 @@
 			"requires": {}
 		},
 		"stylelint-no-unsupported-browser-features": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-7.0.0.tgz",
-			"integrity": "sha512-O5VYlBhr+lpJ6jeTJSy+SMbHJhW5h5EJxsoicYcTi/07m45V/CF1mQidwRQLjv8y9BFQMpioWz60O89IkmbaNw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-6.1.0.tgz",
+			"integrity": "sha512-3Taj+z9PjIiY6cz4hg3eN8Khue3kMm9lPXYuEvdjAFXDK20uQo2NocJaWN6anIKclYlwrpkBAS9W/KV3qPTWsw==",
 			"requires": {
-				"doiuse": "^6.0.1",
+				"doiuse": "^4.4.1",
 				"lodash": "^4.17.15",
 				"postcss": "^8.4.16"
 			}
@@ -6061,23 +6139,29 @@
 			"dev": true
 		},
 		"through2": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"requires": {
-				"readable-stream": ">=1.0.33-1 <1.1.0-0",
-				"xtend": ">=4.0.0 <4.1.0-0"
+				"readable-stream": "3"
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
 					}
 				}
 			}
@@ -6244,24 +6328,17 @@
 			}
 		},
 		"yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
 			"requires": {
-				"cliui": "^8.0.1",
+				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
+				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"dependencies": {
-				"yargs-parser": {
-					"version": "21.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
-				}
+				"yargs-parser": "^20.2.2"
 			}
 		},
 		"yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"postcss-html": "1.5.0",
 		"stylelint": "15.10.1",
 		"stylelint-config-recommended": "13.0.0",
-		"stylelint-no-unsupported-browser-features": "7.0.0",
+		"stylelint-no-unsupported-browser-features": "6.1.0",
 		"stylelint-stylistic": "0.4.3"
 	},
 	"peerDependencies": {

--- a/test/fixtures/basic/invalid.css
+++ b/test/fixtures/basic/invalid.css
@@ -5,7 +5,7 @@ div {
 }
 
 /* Not supported by IE 11, Chrome/Edge/Opera/etc. <=87. */
-/* stylelint-disable-next-line selector-not-notation, plugin/no-unsupported-browser-features */
+/* stylelint-disable-next-line selector-not-notation */
 div:not( .a, .b ) {
 	/* ... */
 }

--- a/test/fixtures/basic/valid.css
+++ b/test/fixtures/basic/valid.css
@@ -1,6 +1,4 @@
 /* Valid: selector-not-notation */
-/* Not supported by Chrome <= 55 and Opera <= 41. */
-/* stylelint-disable-next-line plugin/no-unsupported-browser-features */
 div:not( .a ),
 div:not( .b ) {
 	/* ... */

--- a/test/fixtures/modern/invalid.css
+++ b/test/fixtures/modern/invalid.css
@@ -4,7 +4,7 @@ div {
 	image-orientation: none;
 }
 
-/* stylelint-disable-next-line selector-not-notation, plugin/no-unsupported-browser-features */
+/* stylelint-disable-next-line selector-not-notation */
 div:not( .a, .b ) {
 	/* ... */
 }

--- a/test/fixtures/modern/valid.css
+++ b/test/fixtures/modern/valid.css
@@ -1,5 +1,4 @@
 /* Valid: selector-not-notation */
-/* stylelint-disable-next-line plugin/no-unsupported-browser-features */
 div:not( .a ),
 div:not( .b ) {
 	/* ... */


### PR DESCRIPTION
Due to an upstream bug in doiuse (https://github.com/anandthakker/doiuse/issues/168)
we can't deploy this.
