### PR TITLE
Don't suggest the 'inset' shorthand for top/right/bottom/left

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,9 @@ module.exports = {
 		"stylistic/declaration-bang-space-after": "never",
 		"stylistic/declaration-bang-space-before": "always",
 
-		"declaration-block-no-redundant-longhand-properties": true,
+		"declaration-block-no-redundant-longhand-properties": [ true, {
+			"ignoreShorthands": [ "inset" ]
+		} ],
 		"stylistic/declaration-block-semicolon-newline-after": "always",
 		"stylistic/declaration-block-semicolon-newline-before": "never-multi-line",
 		"stylistic/declaration-block-semicolon-space-after": "always-single-line",

--- a/test/fixtures/default/valid.css
+++ b/test/fixtures/default/valid.css
@@ -10,3 +10,11 @@ div {
 		/* This comment is here to prevent no-empty-source errors */
 	}
 }
+
+.a {
+	/* Valid declaration-block-no-redundant-longhand-properties's ignoreShorthands "inset" option */
+	top: 1px;
+	right: 2px;
+	bottom: 3px;
+	left: 4px;
+}


### PR DESCRIPTION
This requires a fairly modern browser version (after 2020) and
we don't reliable know if CSS needs to run on "basic" browsers.
