### PR TITLE
build: Upgrade to Stylelint 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add a `"rules"` object to your config file, and add your overrides or additional
 {
 	"extends": "stylelint-config-wikimedia/support-basic",
 	"rules": {
-		"stylistic/max-empty-lines": null
+		"@stylistic/max-empty-lines": null
 	}
 }
 ```

--- a/index.js
+++ b/index.js
@@ -6,17 +6,17 @@
 module.exports = {
 	"extends": [
 		"stylelint-config-recommended",
-		"stylelint-stylistic/config"
+		"@stylistic/stylelint-config"
 	],
 	"reportNeedlessDisables": true,
 	"rules": {
 		// Wikimedia Foundation ♡ whitespace in its own special way
 		// See also https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS#Whitespace
-		"stylistic/indentation": "tab",
-		"stylistic/max-empty-lines": 1,
-		"stylistic/max-line-length": null,
-		"stylistic/no-eol-whitespace": true,
-		"stylistic/no-missing-end-of-source-newline": true,
+		"@stylistic/indentation": "tab",
+		"@stylistic/max-empty-lines": 1,
+		"@stylistic/max-line-length": null,
+		"@stylistic/no-eol-whitespace": true,
+		"@stylistic/no-missing-end-of-source-newline": true,
 
 		// Other rules alphabetically
 		"at-rule-empty-line-before": [ "always", {
@@ -26,49 +26,49 @@ module.exports = {
 			],
 			"ignore": "after-comment"
 		} ],
-		"stylistic/at-rule-name-case": "lower",
-		"stylistic/at-rule-name-space-after": "always-single-line",
-		"stylistic/at-rule-semicolon-newline-after": "always",
+		"@stylistic/at-rule-name-case": "lower",
+		"@stylistic/at-rule-name-space-after": "always-single-line",
+		"@stylistic/at-rule-semicolon-newline-after": "always",
 
-		"stylistic/block-closing-brace-empty-line-before": "never",
-		"stylistic/block-closing-brace-newline-after": "always",
-		"stylistic/block-closing-brace-newline-before": "always-multi-line",
-		"stylistic/block-closing-brace-space-after": "always-single-line",
-		"stylistic/block-closing-brace-space-before": "always-single-line",
+		"@stylistic/block-closing-brace-empty-line-before": "never",
+		"@stylistic/block-closing-brace-newline-after": "always",
+		"@stylistic/block-closing-brace-newline-before": "always-multi-line",
+		"@stylistic/block-closing-brace-space-after": "always-single-line",
+		"@stylistic/block-closing-brace-space-before": "always-single-line",
 
-		"stylistic/block-opening-brace-newline-after": "always",
-		"stylistic/block-opening-brace-newline-before": "always-single-line",
-		"stylistic/block-opening-brace-space-after": "always-single-line",
-		"stylistic/block-opening-brace-space-before": "always",
+		"@stylistic/block-opening-brace-newline-after": "always",
+		"@stylistic/block-opening-brace-newline-before": "always-single-line",
+		"@stylistic/block-opening-brace-space-after": "always-single-line",
+		"@stylistic/block-opening-brace-space-before": "always",
 
-		"stylistic/color-hex-case": "lower",
+		"@stylistic/color-hex-case": "lower",
 		"color-hex-length": "short",
 		"color-named": "never",
 
 		"comment-whitespace-inside": "always",
 
-		"stylistic/declaration-bang-space-after": "never",
-		"stylistic/declaration-bang-space-before": "always",
+		"@stylistic/declaration-bang-space-after": "never",
+		"@stylistic/declaration-bang-space-before": "always",
 
 		"declaration-block-no-redundant-longhand-properties": [ true, {
 			"ignoreShorthands": [ "inset" ]
 		} ],
-		"stylistic/declaration-block-semicolon-newline-after": "always",
-		"stylistic/declaration-block-semicolon-newline-before": "never-multi-line",
-		"stylistic/declaration-block-semicolon-space-after": "always-single-line",
-		"stylistic/declaration-block-semicolon-space-before": "never",
+		"@stylistic/declaration-block-semicolon-newline-after": "always",
+		"@stylistic/declaration-block-semicolon-newline-before": "never-multi-line",
+		"@stylistic/declaration-block-semicolon-space-after": "always-single-line",
+		"@stylistic/declaration-block-semicolon-space-before": "never",
 		"declaration-block-single-line-max-declarations": 1,
-		"stylistic/declaration-block-trailing-semicolon": "always",
+		"@stylistic/declaration-block-trailing-semicolon": "always",
 
-		"stylistic/declaration-colon-space-after": "always",
-		"stylistic/declaration-colon-space-before": "never",
+		"@stylistic/declaration-colon-space-after": "always",
+		"@stylistic/declaration-colon-space-before": "never",
 		"declaration-empty-line-before": [ "never", {
 			"ignore": [
 				"after-comment",
 				"inside-single-line-block"
 			]
 		} ],
-		"stylistic/declaration-colon-newline-after": "always-multi-line",
+		"@stylistic/declaration-colon-newline-after": "always-multi-line",
 		"declaration-no-important": true,
 
 		// `px` values disable accessibility browser setting of user font overrides and
@@ -91,41 +91,41 @@ module.exports = {
 		"font-weight-notation": "named-where-possible",
 
 		"function-disallowed-list": "rgb",
-		"stylistic/function-comma-newline-after": "never-multi-line",
-		"stylistic/function-comma-newline-before": "never-multi-line",
-		"stylistic/function-comma-space-after": "always",
-		"stylistic/function-comma-space-before": "never",
-		"stylistic/function-max-empty-lines": 0,
+		"@stylistic/function-comma-newline-after": "never-multi-line",
+		"@stylistic/function-comma-newline-before": "never-multi-line",
+		"@stylistic/function-comma-space-after": "always",
+		"@stylistic/function-comma-space-before": "never",
+		"@stylistic/function-max-empty-lines": 0,
 		"function-name-case": "lower",
-		"stylistic/function-parentheses-newline-inside": "never-multi-line",
-		"stylistic/function-parentheses-space-inside": "always",
+		"@stylistic/function-parentheses-newline-inside": "never-multi-line",
+		"@stylistic/function-parentheses-space-inside": "always",
 		"function-url-no-scheme-relative": true,
 		"function-url-quotes": "never",
-		"stylistic/function-whitespace-after": "always",
+		"@stylistic/function-whitespace-after": "always",
 
 		"length-zero-no-unit": true,
-		"stylistic/linebreaks": "unix",
+		"@stylistic/linebreaks": "unix",
 
-		"stylistic/media-feature-colon-space-after": "always",
-		"stylistic/media-feature-colon-space-before": "never",
-		"stylistic/media-feature-name-case": "lower",
-		"stylistic/media-feature-parentheses-space-inside": "always",
-		"stylistic/media-feature-range-operator-space-after": "always",
-		"stylistic/media-feature-range-operator-space-before": "always",
+		"@stylistic/media-feature-colon-space-after": "always",
+		"@stylistic/media-feature-colon-space-before": "never",
+		"@stylistic/media-feature-name-case": "lower",
+		"@stylistic/media-feature-parentheses-space-inside": "always",
+		"@stylistic/media-feature-range-operator-space-after": "always",
+		"@stylistic/media-feature-range-operator-space-before": "always",
 
-		"stylistic/media-query-list-comma-newline-after": "always-multi-line",
-		"stylistic/media-query-list-comma-newline-before": "never-multi-line",
-		"stylistic/media-query-list-comma-space-after": "always-single-line",
-		"stylistic/media-query-list-comma-space-before": "never",
+		"@stylistic/media-query-list-comma-newline-after": "always-multi-line",
+		"@stylistic/media-query-list-comma-newline-before": "never-multi-line",
+		"@stylistic/media-query-list-comma-space-after": "always-single-line",
+		"@stylistic/media-query-list-comma-space-before": "never",
 
 		"no-unknown-animations": true,
 
 		"media-query-no-invalid": null,
 
-		"stylistic/number-leading-zero": "always",
-		"stylistic/number-no-trailing-zeros": true,
+		"@stylistic/number-leading-zero": "always",
+		"@stylistic/number-no-trailing-zeros": true,
 
-		"stylistic/property-case": "lower",
+		"@stylistic/property-case": "lower",
 
 		"rule-empty-line-before": [
 			"always-multi-line", {
@@ -134,42 +134,42 @@ module.exports = {
 			}
 		],
 
-		"stylistic/selector-attribute-brackets-space-inside": "always",
-		"stylistic/selector-attribute-operator-space-after": "never",
-		"stylistic/selector-attribute-operator-space-before": "never",
+		"@stylistic/selector-attribute-brackets-space-inside": "always",
+		"@stylistic/selector-attribute-operator-space-after": "never",
+		"@stylistic/selector-attribute-operator-space-before": "never",
 		"selector-attribute-quotes": "always",
-		"stylistic/selector-combinator-space-after": "always",
-		"stylistic/selector-combinator-space-before": "always",
-		"stylistic/selector-descendant-combinator-no-non-space": true,
+		"@stylistic/selector-combinator-space-after": "always",
+		"@stylistic/selector-combinator-space-before": "always",
+		"@stylistic/selector-descendant-combinator-no-non-space": true,
 
-		"stylistic/selector-list-comma-newline-after": "always",
-		"stylistic/selector-list-comma-newline-before": "never-multi-line",
-		"stylistic/selector-list-comma-space-after": "always-single-line",
-		"stylistic/selector-list-comma-space-before": "never",
+		"@stylistic/selector-list-comma-newline-after": "always",
+		"@stylistic/selector-list-comma-newline-before": "never-multi-line",
+		"@stylistic/selector-list-comma-space-after": "always-single-line",
+		"@stylistic/selector-list-comma-space-before": "never",
 
-		"stylistic/selector-max-empty-lines": 0,
+		"@stylistic/selector-max-empty-lines": 0,
 		"selector-max-id": 0,
 		"selector-no-vendor-prefix": true,
-		"stylistic/selector-pseudo-class-case": "lower",
-		"stylistic/selector-pseudo-class-parentheses-space-inside": "always",
-		"stylistic/selector-pseudo-element-case": "lower",
+		"@stylistic/selector-pseudo-class-case": "lower",
+		"@stylistic/selector-pseudo-class-parentheses-space-inside": "always",
+		"@stylistic/selector-pseudo-element-case": "lower",
 		"selector-pseudo-element-colon-notation": "double",
 		"selector-type-case": "lower",
 		"selector-type-no-unknown": true,
 
-		"stylistic/string-quotes": "single",
+		"@stylistic/string-quotes": "single",
 
 		"time-min-milliseconds": 100,
 
-		"stylistic/unit-case": "lower",
+		"@stylistic/unit-case": "lower",
 
 		"value-keyword-case": "lower",
-		"stylistic/value-list-max-empty-lines": 0,
+		"@stylistic/value-list-max-empty-lines": 0,
 
-		"stylistic/value-list-comma-newline-after": "never-multi-line",
-		"stylistic/value-list-comma-newline-before": "never-multi-line",
-		"stylistic/value-list-comma-space-after": "always-single-line",
-		"stylistic/value-list-comma-space-before": "never"
+		"@stylistic/value-list-comma-newline-after": "never-multi-line",
+		"@stylistic/value-list-comma-newline-before": "never-multi-line",
+		"@stylistic/value-list-comma-space-after": "always-single-line",
+		"@stylistic/value-list-comma-space-before": "never"
 	},
 	"overrides": [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
 			"version": "0.16.1",
 			"license": "MIT",
 			"dependencies": {
+				"@stylistic/stylelint-config": "1.0.1",
+				"@stylistic/stylelint-plugin": "2.0.0",
 				"browserslist-config-wikimedia": "0.7.0",
 				"postcss-html": "1.6.0",
 				"postcss-less": "6.0.0",
-				"stylelint": "15.10.1",
-				"stylelint-config-recommended": "13.0.0",
-				"stylelint-no-unsupported-browser-features": "6.1.0",
-				"stylelint-stylistic": "0.4.3"
+				"stylelint": "16.2.0",
+				"stylelint-config-recommended": "14.0.0",
+				"stylelint-no-unsupported-browser-features": "8.0.1"
 			},
 			"devDependencies": {
 				"eslint-config-wikimedia": "0.27.0",
@@ -136,9 +137,9 @@
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz",
-			"integrity": "sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
+			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
 			"funding": [
 				{
 					"type": "github",
@@ -153,25 +154,31 @@
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^2.1.1"
+				"@csstools/css-tokenizer": "^2.3.1"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
-			"integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
+			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"node_modules/@csstools/media-query-list-parser": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz",
-			"integrity": "sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==",
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
+			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
 			"funding": [
 				{
 					"type": "github",
@@ -186,14 +193,14 @@
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.3.0",
-				"@csstools/css-tokenizer": "^2.1.1"
+				"@csstools/css-parser-algorithms": "^2.6.3",
+				"@csstools/css-tokenizer": "^2.3.1"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
-			"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
 			"funding": [
 				{
 					"type": "github",
@@ -352,6 +359,41 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@stylistic/stylelint-config": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-config/-/stylelint-config-1.0.1.tgz",
+			"integrity": "sha512-JgFP88HZEyo34k9RpWVdcQJtLPrMxYE58IO3qypXhmvE/NmZohj+xjDtQ8UfaarnYsLecnldw57/GHum07Ctdw==",
+			"dependencies": {
+				"@stylistic/stylelint-plugin": "^2.0.0"
+			},
+			"engines": {
+				"node": "^18.12 || >=20.9"
+			},
+			"peerDependencies": {
+				"stylelint": "^16.0.2"
+			}
+		},
+		"node_modules/@stylistic/stylelint-plugin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-2.0.0.tgz",
+			"integrity": "sha512-dHKuT6PGd1WGZLOTuozAM7GdQzdmlmnFXYzvV1jYJXXpcCpV/OJ3+n8TXpMkoOeKHpJydY43EOoZTO1W/FOA4Q==",
+			"dependencies": {
+				"@csstools/css-parser-algorithms": "^2.3.2",
+				"@csstools/css-tokenizer": "^2.2.1",
+				"@csstools/media-query-list-parser": "^2.1.5",
+				"is-plain-object": "^5.0.0",
+				"postcss-selector-parser": "^6.0.13",
+				"postcss-value-parser": "^4.2.0",
+				"style-search": "^0.1.0",
+				"stylelint": "^16.0.2"
+			},
+			"engines": {
+				"node": "^18.12 || >=20.9"
+			},
+			"peerDependencies": {
+				"stylelint": "^16.0.2"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -363,15 +405,11 @@
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
-		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
-		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"dev": true
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -597,11 +635,11 @@
 			}
 		},
 		"node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/ast-metadata-inferer": {
@@ -717,45 +755,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
-			"dependencies": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001615",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
@@ -828,13 +827,16 @@
 			}
 		},
 		"node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"dependencies": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/color-convert": {
@@ -900,20 +902,28 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/cosmiconfig": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 			"dependencies": {
-				"import-fresh": "^3.2.1",
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0"
+				"parse-json": "^5.2.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -931,45 +941,11 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
-			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.2.tgz",
+			"integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==",
 			"engines": {
-				"node": ">=12.22"
-			}
-		},
-		"node_modules/css-rule-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
-			"integrity": "sha512-qiio/Zkr8I19jh/XuzEkK8OKDQRTrEYaRyIHy4Bwh/tPUe0w8GcQs7r6x24Yc9lT+FbnZFYULxEIXCmaymguUQ==",
-			"dependencies": {
-				"css-tokenize": "^1.0.1",
-				"duplexer2": "0.0.2",
-				"ldjson-stream": "^1.2.1",
-				"through2": "^0.6.3"
-			},
-			"bin": {
-				"css-rule-stream": "index.js"
-			}
-		},
-		"node_modules/css-rule-stream/node_modules/readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/css-rule-stream/node_modules/through2": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-			"dependencies": {
-				"readable-stream": ">=1.0.33-1 <1.1.0-0",
-				"xtend": ">=4.0.0 <4.1.0-0"
+				"node": ">=12 || >=16"
 			}
 		},
 		"node_modules/css-tokenize": {
@@ -1020,48 +996,6 @@
 				}
 			}
 		},
-		"node_modules/decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1092,26 +1026,25 @@
 			}
 		},
 		"node_modules/doiuse": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-4.4.1.tgz",
-			"integrity": "sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-6.0.2.tgz",
+			"integrity": "sha512-eBTs23NOX+EAYPr4RbCR6J4DRW/TML3uMo37y0X1whlkersDYFCk9HmCl09KX98cis22VKsV1QaxfVNauJ3NBw==",
 			"dependencies": {
-				"browserslist": "^4.16.1",
-				"caniuse-lite": "^1.0.30001179",
-				"css-rule-stream": "^1.1.0",
-				"duplexer2": "0.0.2",
+				"browserslist": "^4.21.5",
+				"caniuse-lite": "^1.0.30001487",
+				"css-tokenize": "^1.0.1",
+				"duplexify": "^4.1.2",
 				"ldjson-stream": "^1.2.1",
 				"multimatch": "^5.0.0",
-				"postcss": "^8.2.4",
-				"source-map": "^0.7.3",
-				"through2": "^4.0.2",
-				"yargs": "^16.2.0"
+				"postcss": "^8.4.21",
+				"source-map": "^0.7.4",
+				"yargs": "^17.7.1"
 			},
 			"bin": {
-				"doiuse": "cli.js"
+				"doiuse": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=16"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -1165,12 +1098,36 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
-		"node_modules/duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+		"node_modules/duplexify": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+			"integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
 			"dependencies": {
-				"readable-stream": "~1.1.9"
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.2"
+			}
+		},
+		"node_modules/duplexify/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/duplexify/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -1183,6 +1140,14 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
@@ -1192,6 +1157,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/error-ex": {
@@ -1730,9 +1703,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-			"integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -1787,6 +1760,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1809,6 +1783,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1821,11 +1796,13 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"dev": true,
 			"dependencies": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
@@ -1833,19 +1810,21 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -1874,6 +1853,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1993,14 +1973,6 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2013,6 +1985,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
 			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -2056,9 +2029,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -2076,14 +2049,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/import-lazy": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/imurmurhash": {
@@ -2107,6 +2072,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -2146,6 +2112,7 @@
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
 			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.0"
 			},
@@ -2197,14 +2164,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -2224,9 +2183,9 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/js-tokens": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.0.tgz",
-			"integrity": "sha512-PC7MzqInq9OqKyTXfIvQNcjMkODJYC8A17kAaQgeW79yfhqTWSOfjHYQ2mDDcwJ96Iibtwkfh0C7R/OvqPlgVA=="
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
+			"integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw=="
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2260,6 +2219,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2277,6 +2241,14 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2286,9 +2258,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
-			"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg=="
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
+			"integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
 		},
 		"node_modules/ldjson-stream": {
 			"version": "1.2.1",
@@ -2297,26 +2269,6 @@
 			"dependencies": {
 				"split2": "^0.2.1",
 				"through2": "^0.6.1"
-			}
-		},
-		"node_modules/ldjson-stream/node_modules/readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/ldjson-stream/node_modules/through2": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-			"dependencies": {
-				"readable-stream": ">=1.0.33-1 <1.1.0-0",
-				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
 		"node_modules/levn": {
@@ -2341,6 +2293,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2354,7 +2307,8 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
@@ -2373,28 +2327,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/mathml-tag-names": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -2410,94 +2342,11 @@
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/meow": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
-			},
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg-up": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-			"dependencies": {
-				"find-up": "^5.0.0",
-				"read-pkg": "^6.0.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2527,6 +2376,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2540,19 +2390,6 @@
 			},
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/ms": {
@@ -2576,14 +2413,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/multimatch/node_modules/arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/nanoid": {
@@ -2693,6 +2522,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2707,6 +2537,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2758,6 +2589,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2766,6 +2598,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2870,11 +2703,6 @@
 				"postcss": "^8.3.5"
 			}
 		},
-		"node_modules/postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
-		},
 		"node_modules/postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
@@ -2947,17 +2775,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/qunit": {
 			"version": "2.20.1",
@@ -3085,54 +2902,14 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.1",
 				"isarray": "0.0.1",
 				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/redent/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/redent/node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/regexp-tree": {
@@ -3237,6 +3014,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -3298,12 +3076,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -3387,6 +3163,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
 			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"dev": true,
 			"dependencies": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -3395,12 +3172,14 @@
 		"node_modules/spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -3409,7 +3188,8 @@
 		"node_modules/spdx-license-ids": {
 			"version": "3.0.12",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+			"dev": true
 		},
 		"node_modules/split2": {
 			"version": "0.2.1",
@@ -3419,25 +3199,10 @@
 				"through2": "~0.6.1"
 			}
 		},
-		"node_modules/split2/node_modules/readable-stream": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/split2/node_modules/through2": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-			"dependencies": {
-				"readable-stream": ">=1.0.33-1 <1.1.0-0",
-				"xtend": ">=4.0.0 <4.1.0-0"
-			}
+		"node_modules/stream-shift": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
 		},
 		"node_modules/string_decoder": {
 			"version": "0.10.31",
@@ -3498,46 +3263,44 @@
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
 		},
 		"node_modules/stylelint": {
-			"version": "15.10.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
-			"integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.0.tgz",
+			"integrity": "sha512-gwqU5AkIb52wrAzzn+359S3NIJDMl02TXLUaV2tzA/L6jUdpTwNt+MCxHlc8+Hb2bUHlYVo92YeSIryF2gJthA==",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.3.0",
-				"@csstools/css-tokenizer": "^2.1.1",
-				"@csstools/media-query-list-parser": "^2.1.2",
-				"@csstools/selector-specificity": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^2.5.0",
+				"@csstools/css-tokenizer": "^2.2.3",
+				"@csstools/media-query-list-parser": "^2.1.7",
+				"@csstools/selector-specificity": "^3.0.1",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^8.2.0",
-				"css-functions-list": "^3.1.0",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.1",
 				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.3.0",
+				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^6.0.1",
+				"file-entry-cache": "^8.0.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.2.4",
-				"import-lazy": "^4.0.0",
+				"ignore": "^5.3.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.27.0",
+				"known-css-properties": "^0.29.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^10.1.5",
+				"meow": "^13.1.0",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.24",
+				"postcss": "^8.4.33",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.13",
+				"postcss-safe-parser": "^7.0.0",
+				"postcss-selector-parser": "^6.0.15",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
+				"strip-ansi": "^7.1.0",
 				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.8.1",
@@ -3547,7 +3310,7 @@
 				"stylelint": "bin/stylelint.mjs"
 			},
 			"engines": {
-				"node": "^14.13.1 || >=16.0.0"
+				"node": ">=18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3555,45 +3318,40 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
-			"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
+			"integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
 			"engines": {
-				"node": "^14.13.1 || >=16.0.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^15.10.0"
+				"stylelint": "^16.0.0"
 			}
 		},
 		"node_modules/stylelint-no-unsupported-browser-features": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-6.1.0.tgz",
-			"integrity": "sha512-3Taj+z9PjIiY6cz4hg3eN8Khue3kMm9lPXYuEvdjAFXDK20uQo2NocJaWN6anIKclYlwrpkBAS9W/KV3qPTWsw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-8.0.1.tgz",
+			"integrity": "sha512-tc8Xn5DaqJhxTmbA4H8gZbYdAz027NfuSZv5+cVieQb7BtBrF/1/iKYdpcGwXPl3GtqkQrisiXuGqKkKnzWcLw==",
 			"dependencies": {
-				"doiuse": "^4.4.1",
-				"lodash": "^4.17.15",
-				"postcss": "^8.4.16"
+				"doiuse": "^6.0.2",
+				"postcss": "^8.4.32"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^14.0.0||^15.0.0"
+				"stylelint": "^16.0.2"
 			}
 		},
-		"node_modules/stylelint-stylistic": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
-			"integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
-			"dependencies": {
-				"is-plain-object": "^5.0.0",
-				"postcss": "^8.4.21",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-value-parser": "^4.2.0",
-				"style-search": "^0.1.0"
+		"node_modules/stylelint/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"engines": {
+				"node": ">=12"
 			},
-			"peerDependencies": {
-				"stylelint": "^15.0.0"
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
@@ -3601,12 +3359,74 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
 		},
+		"node_modules/stylelint/node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/stylelint/node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/stylelint/node_modules/postcss-safe-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+			"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"engines": {
+				"node": ">=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
 		"node_modules/stylelint/node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/stylelint/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/supports-color": {
@@ -3665,14 +3485,14 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
+			"integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
 				"json-schema-traverse": "^1.0.0",
 				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"uri-js": "^4.4.1"
 			},
 			"funding": {
 				"type": "github",
@@ -3691,32 +3511,12 @@
 			"dev": true
 		},
 		"node_modules/through2": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
 			"dependencies": {
-				"readable-stream": "3"
-			}
-		},
-		"node_modules/through2/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/through2/node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
+				"readable-stream": ">=1.0.33-1 <1.1.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
 		"node_modules/tiny-glob": {
@@ -3738,17 +3538,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/trim-newlines": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tslib": {
@@ -3800,7 +3589,7 @@
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-			"dev": true,
+			"devOptional": true,
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3866,6 +3655,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -3968,11 +3758,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"node_modules/yaml": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
@@ -4003,34 +3788,35 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dependencies": {
-				"cliui": "^7.0.2",
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
+				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
+				"yargs-parser": "^21.1.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -4126,26 +3912,26 @@
 			}
 		},
 		"@csstools/css-parser-algorithms": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz",
-			"integrity": "sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
+			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
 			"requires": {}
 		},
 		"@csstools/css-tokenizer": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
-			"integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
+			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g=="
 		},
 		"@csstools/media-query-list-parser": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz",
-			"integrity": "sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==",
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
+			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
 			"requires": {}
 		},
 		"@csstools/selector-specificity": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
-			"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
 			"requires": {}
 		},
 		"@es-joy/jsdoccomment": {
@@ -4249,6 +4035,29 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@stylistic/stylelint-config": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-config/-/stylelint-config-1.0.1.tgz",
+			"integrity": "sha512-JgFP88HZEyo34k9RpWVdcQJtLPrMxYE58IO3qypXhmvE/NmZohj+xjDtQ8UfaarnYsLecnldw57/GHum07Ctdw==",
+			"requires": {
+				"@stylistic/stylelint-plugin": "^2.0.0"
+			}
+		},
+		"@stylistic/stylelint-plugin": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-2.0.0.tgz",
+			"integrity": "sha512-dHKuT6PGd1WGZLOTuozAM7GdQzdmlmnFXYzvV1jYJXXpcCpV/OJ3+n8TXpMkoOeKHpJydY43EOoZTO1W/FOA4Q==",
+			"requires": {
+				"@csstools/css-parser-algorithms": "^2.3.2",
+				"@csstools/css-tokenizer": "^2.2.1",
+				"@csstools/media-query-list-parser": "^2.1.5",
+				"is-plain-object": "^5.0.0",
+				"postcss-selector-parser": "^6.0.13",
+				"postcss-value-parser": "^4.2.0",
+				"style-search": "^0.1.0",
+				"stylelint": "^16.0.2"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4260,15 +4069,11 @@
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
-		"@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"dev": true
 		},
 		"@types/semver": {
 			"version": "7.5.8",
@@ -4417,9 +4222,9 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
 		},
 		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
 		},
 		"ast-metadata-inferer": {
 			"version": "0.8.0",
@@ -4499,29 +4304,6 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
-		"camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
-		},
-		"camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
-			"requires": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-				}
-			}
-		},
 		"caniuse-lite": {
 			"version": "1.0.30001615",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
@@ -4561,12 +4343,12 @@
 			}
 		},
 		"cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"requires": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
@@ -4620,14 +4402,14 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cosmiconfig": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 			"requires": {
-				"import-fresh": "^3.2.1",
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0"
+				"parse-json": "^5.2.0"
 			}
 		},
 		"cross-spawn": {
@@ -4642,42 +4424,9 @@
 			}
 		},
 		"css-functions-list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
-			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w=="
-		},
-		"css-rule-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
-			"integrity": "sha512-qiio/Zkr8I19jh/XuzEkK8OKDQRTrEYaRyIHy4Bwh/tPUe0w8GcQs7r6x24Yc9lT+FbnZFYULxEIXCmaymguUQ==",
-			"requires": {
-				"css-tokenize": "^1.0.1",
-				"duplexer2": "0.0.2",
-				"ldjson-stream": "^1.2.1",
-				"through2": "^0.6.3"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				}
-			}
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.2.tgz",
+			"integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ=="
 		},
 		"css-tokenize": {
 			"version": "1.0.1",
@@ -4710,32 +4459,6 @@
 				"ms": "2.1.2"
 			}
 		},
-		"decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
-		},
-		"decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"decamelize": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg=="
-				}
-			}
-		},
 		"deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4760,20 +4483,19 @@
 			}
 		},
 		"doiuse": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-4.4.1.tgz",
-			"integrity": "sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/doiuse/-/doiuse-6.0.2.tgz",
+			"integrity": "sha512-eBTs23NOX+EAYPr4RbCR6J4DRW/TML3uMo37y0X1whlkersDYFCk9HmCl09KX98cis22VKsV1QaxfVNauJ3NBw==",
 			"requires": {
-				"browserslist": "^4.16.1",
-				"caniuse-lite": "^1.0.30001179",
-				"css-rule-stream": "^1.1.0",
-				"duplexer2": "0.0.2",
+				"browserslist": "^4.21.5",
+				"caniuse-lite": "^1.0.30001487",
+				"css-tokenize": "^1.0.1",
+				"duplexify": "^4.1.2",
 				"ldjson-stream": "^1.2.1",
 				"multimatch": "^5.0.0",
-				"postcss": "^8.2.4",
-				"source-map": "^0.7.3",
-				"through2": "^4.0.2",
-				"yargs": "^16.2.0"
+				"postcss": "^8.4.21",
+				"source-map": "^0.7.4",
+				"yargs": "^17.7.1"
 			}
 		},
 		"dom-serializer": {
@@ -4809,12 +4531,35 @@
 				"domhandler": "^5.0.1"
 			}
 		},
-		"duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+		"duplexify": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+			"integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
 			"requires": {
-				"readable-stream": "~1.1.9"
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.2"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				}
 			}
 		},
 		"electron-to-chromium": {
@@ -4827,10 +4572,23 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"entities": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
 			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+		},
+		"env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -5218,9 +4976,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-			"integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -5268,6 +5026,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
 			}
@@ -5284,34 +5043,39 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
 			}
 		},
 		"flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"dev": true,
 			"requires": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			}
 		},
 		"flatted": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -5331,6 +5095,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5422,11 +5187,6 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
-		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5436,6 +5196,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
 			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.2"
 			}
@@ -5463,9 +5224,9 @@
 			}
 		},
 		"ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -5475,11 +5236,6 @@
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
 			}
-		},
-		"import-lazy": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -5496,6 +5252,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -5529,6 +5286,7 @@
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
 			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
 			"requires": {
 				"hasown": "^2.0.0"
 			}
@@ -5562,11 +5320,6 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
-		},
 		"is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -5583,9 +5336,9 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"js-tokens": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.0.tgz",
-			"integrity": "sha512-PC7MzqInq9OqKyTXfIvQNcjMkODJYC8A17kAaQgeW79yfhqTWSOfjHYQ2mDDcwJ96Iibtwkfh0C7R/OvqPlgVA=="
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
+			"integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw=="
 		},
 		"js-yaml": {
 			"version": "4.1.0",
@@ -5607,6 +5360,11 @@
 			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5624,15 +5382,23 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"requires": {
+				"json-buffer": "3.0.1"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"known-css-properties": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
-			"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg=="
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
+			"integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
 		},
 		"ldjson-stream": {
 			"version": "1.2.1",
@@ -5641,28 +5407,6 @@
 			"requires": {
 				"split2": "^0.2.1",
 				"through2": "^0.6.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				}
 			}
 		},
 		"levn": {
@@ -5684,6 +5428,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
@@ -5691,7 +5436,8 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -5710,19 +5456,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
-		"map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
-		},
 		"mathml-tag-names": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -5734,70 +5467,9 @@
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"meow": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
-			"requires": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
-			},
-			"dependencies": {
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^3.0.2",
-						"parse-json": "^5.2.0",
-						"type-fest": "^1.0.1"
-					}
-				},
-				"read-pkg-up": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-					"requires": {
-						"find-up": "^5.0.0",
-						"read-pkg": "^6.0.0",
-						"type-fest": "^1.0.1"
-					}
-				},
-				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-				}
-			}
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="
 		},
 		"merge2": {
 			"version": "1.4.1",
@@ -5816,7 +5488,8 @@
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.1.2",
@@ -5824,16 +5497,6 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
 			}
 		},
 		"ms": {
@@ -5851,13 +5514,6 @@
 				"array-union": "^2.1.0",
 				"arrify": "^2.0.1",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"arrify": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-				}
 			}
 		},
 		"nanoid": {
@@ -5942,6 +5598,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
@@ -5950,6 +5607,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
@@ -5982,12 +5640,14 @@
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -6049,11 +5709,6 @@
 			"integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
 			"requires": {}
 		},
-		"postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
-		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
@@ -6094,11 +5749,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-		},
-		"quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
 		},
 		"qunit": {
 			"version": "2.20.1",
@@ -6194,38 +5844,14 @@
 			}
 		},
 		"readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.1",
 				"isarray": "0.0.1",
 				"string_decoder": "~0.10.x"
-			}
-		},
-		"redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"requires": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-				},
-				"strip-indent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-					"requires": {
-						"min-indent": "^1.0.1"
-					}
-				}
 			}
 		},
 		"regexp-tree": {
@@ -6298,6 +5924,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -6325,12 +5952,10 @@
 			}
 		},
 		"semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -6381,6 +6006,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
 			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -6389,12 +6015,14 @@
 		"spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -6403,7 +6031,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.12",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+			"dev": true
 		},
 		"split2": {
 			"version": "0.2.1",
@@ -6411,29 +6040,12 @@
 			"integrity": "sha512-D/oTExYAkC9nWleOCTOyNmAuzfAT/6rHGBA9LIK7FVnGo13CSvrKCUzKenwH6U1s2znY9MqH6v0UQTEDa3vJmg==",
 			"requires": {
 				"through2": "~0.6.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				}
 			}
+		},
+		"stream-shift": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
 		},
 		"string_decoder": {
 			"version": "0.10.31",
@@ -6479,90 +6091,111 @@
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
 		},
 		"stylelint": {
-			"version": "15.10.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
-			"integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.0.tgz",
+			"integrity": "sha512-gwqU5AkIb52wrAzzn+359S3NIJDMl02TXLUaV2tzA/L6jUdpTwNt+MCxHlc8+Hb2bUHlYVo92YeSIryF2gJthA==",
 			"requires": {
-				"@csstools/css-parser-algorithms": "^2.3.0",
-				"@csstools/css-tokenizer": "^2.1.1",
-				"@csstools/media-query-list-parser": "^2.1.2",
-				"@csstools/selector-specificity": "^3.0.0",
+				"@csstools/css-parser-algorithms": "^2.5.0",
+				"@csstools/css-tokenizer": "^2.2.3",
+				"@csstools/media-query-list-parser": "^2.1.7",
+				"@csstools/selector-specificity": "^3.0.1",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^8.2.0",
-				"css-functions-list": "^3.1.0",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.1",
 				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.3.0",
+				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^6.0.1",
+				"file-entry-cache": "^8.0.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.2.4",
-				"import-lazy": "^4.0.0",
+				"ignore": "^5.3.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.27.0",
+				"known-css-properties": "^0.29.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^10.1.5",
+				"meow": "^13.1.0",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.24",
+				"postcss": "^8.4.33",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.13",
+				"postcss-safe-parser": "^7.0.0",
+				"postcss-selector-parser": "^6.0.15",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
+				"strip-ansi": "^7.1.0",
 				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.8.1",
 				"write-file-atomic": "^5.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+				},
 				"balanced-match": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
 				},
+				"file-entry-cache": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+					"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+					"requires": {
+						"flat-cache": "^4.0.0"
+					}
+				},
+				"flat-cache": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+					"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+					"requires": {
+						"flatted": "^3.2.9",
+						"keyv": "^4.5.4"
+					}
+				},
+				"postcss-safe-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+					"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+					"requires": {}
+				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+				},
+				"strip-ansi": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					}
 				}
 			}
 		},
 		"stylelint-config-recommended": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
-			"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
+			"integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
 			"requires": {}
 		},
 		"stylelint-no-unsupported-browser-features": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-6.1.0.tgz",
-			"integrity": "sha512-3Taj+z9PjIiY6cz4hg3eN8Khue3kMm9lPXYuEvdjAFXDK20uQo2NocJaWN6anIKclYlwrpkBAS9W/KV3qPTWsw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-8.0.1.tgz",
+			"integrity": "sha512-tc8Xn5DaqJhxTmbA4H8gZbYdAz027NfuSZv5+cVieQb7BtBrF/1/iKYdpcGwXPl3GtqkQrisiXuGqKkKnzWcLw==",
 			"requires": {
-				"doiuse": "^4.4.1",
-				"lodash": "^4.17.15",
-				"postcss": "^8.4.16"
-			}
-		},
-		"stylelint-stylistic": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
-			"integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
-			"requires": {
-				"is-plain-object": "^5.0.0",
-				"postcss": "^8.4.21",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-value-parser": "^4.2.0",
-				"style-search": "^0.1.0"
+				"doiuse": "^6.0.2",
+				"postcss": "^8.4.32"
 			}
 		},
 		"supports-color": {
@@ -6606,14 +6239,14 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"version": "8.14.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
+					"integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
 					"requires": {
-						"fast-deep-equal": "^3.1.1",
+						"fast-deep-equal": "^3.1.3",
 						"json-schema-traverse": "^1.0.0",
 						"require-from-string": "^2.0.2",
-						"uri-js": "^4.2.2"
+						"uri-js": "^4.4.1"
 					}
 				},
 				"json-schema-traverse": {
@@ -6630,31 +6263,12 @@
 			"dev": true
 		},
 		"through2": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
 			"requires": {
-				"readable-stream": "3"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				}
+				"readable-stream": ">=1.0.33-1 <1.1.0-0",
+				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
 		"tiny-glob": {
@@ -6674,11 +6288,6 @@
 			"requires": {
 				"is-number": "^7.0.0"
 			}
-		},
-		"trim-newlines": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ=="
 		},
 		"tslib": {
 			"version": "1.14.1",
@@ -6714,7 +6323,7 @@
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-			"dev": true,
+			"devOptional": true,
 			"peer": true
 		},
 		"upath": {
@@ -6749,6 +6358,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -6818,11 +6428,6 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
 		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"yaml": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
@@ -6841,28 +6446,29 @@
 			}
 		},
 		"yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"requires": {
-				"cliui": "^7.0.2",
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
+				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
+				"yargs-parser": "^21.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
 		"browserslist-config-wikimedia": "0.7.0",
 		"postcss-less": "6.0.0",
 		"postcss-html": "1.6.0",
-		"stylelint": "15.10.1",
-		"stylelint-config-recommended": "13.0.0",
-		"stylelint-no-unsupported-browser-features": "6.1.0",
-		"stylelint-stylistic": "0.4.3"
+		"stylelint": "16.2.0",
+		"stylelint-config-recommended": "14.0.0",
+		"stylelint-no-unsupported-browser-features": "8.0.1",
+		"@stylistic/stylelint-config": "1.0.1",
+		"@stylistic/stylelint-plugin": "2.0.0"
 	},
 	"peerDependencies": {
 		"postcss-less": "^6.0.0"

--- a/support-basic-rules.js
+++ b/support-basic-rules.js
@@ -9,6 +9,7 @@ module.exports = {
 		"plugin/no-unsupported-browser-features": [ true, {
 			"browsers": require( 'browserslist-config-wikimedia/basic' ),
 			"severity": "warning",
+			"ignore": [ "css-not-sel-list" ],
 			"ignorePartialSupport": true
 		} ],
 		// Must remain enabled as long as some of our "basic" browsers don't support https://caniuse.com/css-not-sel-list

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -1,20 +1,20 @@
-/* We can't test no-empty-source or stylistic/no-empty-first-line */
+/* We can't test no-empty-source or @stylistic/no-empty-first-line */
 /* skip-stylelint-disable no-empty-source */
-/* skip-stylelint-disable stylistic/no-empty-first-line */
+/* skip-stylelint-disable @stylistic/no-empty-first-line */
 
 div {
-	/* stylelint-disable-next-line stylistic/indentation */
+	/* stylelint-disable-next-line @stylistic/indentation */
     width: 1px;
-	/* stylelint-disable stylistic/max-empty-lines */
+	/* stylelint-disable @stylistic/max-empty-lines */
 
 
-	/* stylelint-enable stylistic/max-empty-lines */
+	/* stylelint-enable @stylistic/max-empty-lines */
 	height: 1px;
-	/* stylelint-disable-next-line stylistic/no-eol-whitespace, stylistic/declaration-block-semicolon-newline-after, stylistic/declaration-block-semicolon-newline-before, stylistic/declaration-block-semicolon-space-before */
+	/* stylelint-disable-next-line @stylistic/no-eol-whitespace, @stylistic/declaration-block-semicolon-newline-after, @stylistic/declaration-block-semicolon-newline-before, @stylistic/declaration-block-semicolon-space-before */
 	color: #fff ; 
 	background: #000;
 }
-@Media( max-width: 600px ) { /* stylelint-disable-line at-rule-empty-line-before, stylistic/at-rule-name-case, stylistic/at-rule-name-space-after */
+@Media( max-width: 600px ) { /* stylelint-disable-line at-rule-empty-line-before, @stylistic/at-rule-name-case, @stylistic/at-rule-name-space-after */
 	color: #fff;
 }
 
@@ -23,19 +23,19 @@ div {
 	color: #fff;
 }
 
-/* stylelint-disable-next-line stylistic/at-rule-semicolon-newline-after, no-invalid-position-at-import-rule, no-duplicate-at-import-rules */
+/* stylelint-disable-next-line @stylistic/at-rule-semicolon-newline-after, no-invalid-position-at-import-rule, no-duplicate-at-import-rules */
 @import url( x.css ); @import url( x.css );
 
 span {
 	color: #fff;
 
-} /* stylelint-disable-line stylistic/block-closing-brace-empty-line-before */
+} /* stylelint-disable-line @stylistic/block-closing-brace-empty-line-before */
 
-/* stylelint-disable-next-line stylistic/block-closing-brace-newline-after, stylistic/block-closing-brace-space-after, stylistic/block-closing-brace-space-before, stylistic/block-opening-brace-newline-after, stylistic/block-opening-brace-newline-before, stylistic/block-opening-brace-space-after, stylistic/block-opening-brace-space-before */
+/* stylelint-disable-next-line @stylistic/block-closing-brace-newline-after, @stylistic/block-closing-brace-space-after, @stylistic/block-closing-brace-space-before, @stylistic/block-opening-brace-newline-after, @stylistic/block-opening-brace-newline-before, @stylistic/block-opening-brace-space-after, @stylistic/block-opening-brace-space-before */
 .a{color: #fff;}.b{color: #fff;}
 
 .b2 {
-	/* stylelint-disable-next-line stylistic/block-closing-brace-newline-before */
+	/* stylelint-disable-next-line @stylistic/block-closing-brace-newline-before */
 	color: #fff;}
 
 /* stylelint-disable-next-line block-no-empty */
@@ -43,7 +43,7 @@ span {
 }
 
 .d {
-	/* stylelint-disable-next-line stylistic/color-hex-case, color-hex-length */
+	/* stylelint-disable-next-line @stylistic/color-hex-case, color-hex-length */
 	color: #FFFFFF;
 	/* stylelint-disable-next-line color-named */
 	background: red;
@@ -61,7 +61,7 @@ span {
 .e {
 	/* stylelint-disable-next-line custom-property-no-missing-var-function */
 	color: --foo;
-	/* stylelint-disable-next-line stylistic/declaration-bang-space-after, stylistic/declaration-bang-space-before, declaration-no-important */
+	/* stylelint-disable-next-line @stylistic/declaration-bang-space-after, @stylistic/declaration-bang-space-before, declaration-no-important */
 	color: #fff! important;
 	background: #fff;
 	/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
@@ -79,14 +79,14 @@ span {
 	padding-left: 4px;
 	/* stylelint-disable-next-line declaration-block-no-shorthand-property-overrides */
 	padding: 0;
-	/* stylelint-disable-next-line stylistic/declaration-block-semicolon-newline-after */
+	/* stylelint-disable-next-line @stylistic/declaration-block-semicolon-newline-after */
 	margin: 0;outline: 0;
-	/* stylelint-disable-next-line stylistic/declaration-block-trailing-semicolon */
+	/* stylelint-disable-next-line @stylistic/declaration-block-trailing-semicolon */
 	color: #000
 }
 
 .g {
-	/* stylelint-disable-next-line stylistic/declaration-colon-space-after, stylistic/declaration-colon-space-before */
+	/* stylelint-disable-next-line @stylistic/declaration-colon-space-after, @stylistic/declaration-colon-space-before */
 	color :#000;
 }
 
@@ -95,7 +95,7 @@ span {
 	color: #000; /* stylelint-disable-line declaration-empty-line-before */
 }
 
-/* stylelint-disable-next-line declaration-block-single-line-max-declarations, stylistic/declaration-block-semicolon-space-after, stylistic/declaration-block-semicolon-newline-after, stylistic/block-opening-brace-newline-before, stylistic/block-opening-brace-newline-after, stylistic/block-closing-brace-space-after */
+/* stylelint-disable-next-line declaration-block-single-line-max-declarations, @stylistic/declaration-block-semicolon-space-after, @stylistic/declaration-block-semicolon-newline-after, @stylistic/block-opening-brace-newline-before, @stylistic/block-opening-brace-newline-after, @stylistic/block-closing-brace-space-after */
 .i { margin: 0;padding: 0; }
 
 .j {
@@ -115,12 +115,12 @@ span {
 	font-weight: 400;
 	/* stylelint-disable-next-line function-disallowed-list */
 	color: rgb( 0, 0, 0 );
-	/* stylelint-disable-next-line function-calc-no-unspaced-operator, stylistic/function-parentheses-space-inside, unit-no-unknown */
+	/* stylelint-disable-next-line function-calc-no-unspaced-operator, @stylistic/function-parentheses-space-inside, unit-no-unknown */
 	top: calc(1pxx+2pxx);
-	/* stylelint-disable-next-line stylistic/function-comma-newline-after, stylistic/function-comma-newline-before, stylistic/function-comma-space-after, stylistic/function-comma-space-before, stylistic/function-parentheses-space-inside, stylistic/function-max-empty-lines, stylistic/value-list-max-empty-lines, stylistic/declaration-colon-newline-after */
+	/* stylelint-disable-next-line @stylistic/function-comma-newline-after, @stylistic/function-comma-newline-before, @stylistic/function-comma-space-after, @stylistic/function-comma-space-before, @stylistic/function-parentheses-space-inside, @stylistic/function-max-empty-lines, @stylistic/value-list-max-empty-lines, @stylistic/declaration-colon-newline-after */
 	transform: translate(1 ,
 
-	1 ); /* stylelint-disable-line stylistic/function-parentheses-newline-inside */
+	1 ); /* stylelint-disable-line @stylistic/function-parentheses-newline-inside */
 	/* stylelint-disable-next-line function-no-unknown */
 	transform: something( 2 );
 }
@@ -130,7 +130,7 @@ span {
 	background: Linear-gradient( top, #fff, #000 );
 	/* stylelint-disable-next-line function-url-no-scheme-relative, function-url-quotes */
 	background-image: url( '//en.wikipedia.org' );
-	/* stylelint-disable-next-line stylistic/function-whitespace-after */
+	/* stylelint-disable-next-line @stylistic/function-whitespace-after */
 	transform: translate( 1, 1 )scale( 3 );
 	/* stylelint-disable-next-line length-zero-no-unit */
 	top: 0px;
@@ -147,7 +147,7 @@ span {
 	}
 }
 
-/* stylelint-disable-next-line stylistic/media-feature-colon-space-after, stylistic/media-feature-colon-space-before, stylistic/media-feature-name-case, stylistic/media-feature-parentheses-space-inside */
+/* stylelint-disable-next-line @stylistic/media-feature-colon-space-after, @stylistic/media-feature-colon-space-before, @stylistic/media-feature-name-case, @stylistic/media-feature-parentheses-space-inside */
 @media ( MAX-width :600px) {
 	/* ... */
 }
@@ -157,17 +157,17 @@ span {
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/media-feature-range-operator-space-after, stylistic/media-feature-range-operator-space-before */
+/* stylelint-disable-next-line @stylistic/media-feature-range-operator-space-after, @stylistic/media-feature-range-operator-space-before */
 @media ( width>=600px ) {
 	/* ... */
 }
 
 @media screen and ( color )
-	, projection and ( color ) { /* stylelint-disable-line stylistic/media-query-list-comma-newline-after, stylistic/media-query-list-comma-newline-before, stylistic/media-query-list-comma-space-before */
+	, projection and ( color ) { /* stylelint-disable-line @stylistic/media-query-list-comma-newline-after, @stylistic/media-query-list-comma-newline-before, @stylistic/media-query-list-comma-space-before */
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/media-query-list-comma-space-after */
+/* stylelint-disable-next-line @stylistic/media-query-list-comma-space-after */
 @media screen and ( color ),projection and ( color ) {
 	/* ... */
 }
@@ -197,37 +197,37 @@ span {
 .k {
 	/* stylelint-disable-next-line no-invalid-double-slash-comments, property-no-unknown */
 	//color: #fff;
-	/* stylelint-disable-next-line stylistic/no-extra-semicolons */
+	/* stylelint-disable-next-line @stylistic/no-extra-semicolons */
 	;
 	/* stylelint-disable-next-line no-unknown-animations */
 	animation-name: fancy-slide;
-	/* stylelint-disable-next-line stylistic/number-leading-zero, stylistic/number-no-trailing-zeros */
+	/* stylelint-disable-next-line @stylistic/number-leading-zero, @stylistic/number-no-trailing-zeros */
 	top: .10px;
-	/* stylelint-disable-next-line stylistic/property-case */
+	/* stylelint-disable-next-line @stylistic/property-case */
 	Background: #000;
 }
 .l { /* stylelint-disable-line rule-empty-line-before */
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/selector-attribute-brackets-space-inside, stylistic/selector-attribute-operator-space-after, stylistic/selector-attribute-operator-space-before, selector-attribute-quotes */
+/* stylelint-disable-next-line @stylistic/selector-attribute-brackets-space-inside, @stylistic/selector-attribute-operator-space-after, @stylistic/selector-attribute-operator-space-before, selector-attribute-quotes */
 [title = foo] {
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/selector-combinator-space-after, stylistic/selector-combinator-space-before, stylistic/selector-descendant-combinator-no-non-space */
+/* stylelint-disable-next-line @stylistic/selector-combinator-space-after, @stylistic/selector-combinator-space-before, @stylistic/selector-descendant-combinator-no-non-space */
 .m+.n  .o {
 	/* ... */
 }
 
-.p ,.q { /* stylelint-disable-line stylistic/selector-list-comma-newline-after, stylistic/selector-list-comma-space-after, stylistic/selector-list-comma-space-before */
+.p ,.q { /* stylelint-disable-line @stylistic/selector-list-comma-newline-after, @stylistic/selector-list-comma-space-after, @stylistic/selector-list-comma-space-before */
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/selector-max-empty-lines */
+/* stylelint-disable-next-line @stylistic/selector-max-empty-lines */
 .r
 
-, .s { /* stylelint-disable-line stylistic/selector-list-comma-newline-after, stylistic/selector-list-comma-newline-before, stylistic/selector-list-comma-space-before */
+, .s { /* stylelint-disable-line @stylistic/selector-list-comma-newline-after, @stylistic/selector-list-comma-newline-before, @stylistic/selector-list-comma-space-before */
 	/* ... */
 }
 
@@ -236,7 +236,7 @@ span {
 	/* ... */
 }
 
-/* stylelint-disable-next-line stylistic/selector-pseudo-class-case, selector-pseudo-class-no-unknown, stylistic/selector-pseudo-class-parentheses-space-inside, stylistic/selector-pseudo-element-case, selector-pseudo-element-colon-notation, selector-pseudo-element-no-unknown */
+/* stylelint-disable-next-line @stylistic/selector-pseudo-class-case, selector-pseudo-class-no-unknown, @stylistic/selector-pseudo-class-parentheses-space-inside, @stylistic/selector-pseudo-element-case, selector-pseudo-element-colon-notation, selector-pseudo-element-no-unknown */
 .t:HOVER:unknown:not(.a):BEFORE::pseudo {
 	/* ... */
 }
@@ -257,25 +257,25 @@ a:nth-child( 0n+0 ) {
 }
 
 .u {
-	/* stylelint-disable-next-line string-no-newline, stylistic/string-quotes, stylistic/declaration-colon-newline-after */
+	/* stylelint-disable-next-line string-no-newline, @stylistic/string-quotes, @stylistic/declaration-colon-newline-after */
 	content: "a
 	b";
 	/* stylelint-disable-next-line time-min-milliseconds */
 	animation: 80ms;
-	/* stylelint-disable-next-line stylistic/unit-case */
+	/* stylelint-disable-next-line @stylistic/unit-case */
 	top: 1REM;
 	/* stylelint-disable-next-line value-keyword-case */
 	display: BLOCK;
-	/* stylelint-disable stylistic/value-list-max-empty-lines, stylistic/declaration-colon-newline-after */
+	/* stylelint-disable @stylistic/value-list-max-empty-lines, @stylistic/declaration-colon-newline-after */
 	padding: 1px
 
 		2px;
-	/* stylelint-enable stylistic/value-list-max-empty-lines */
-	/* stylelint-disable-next-line stylistic/value-list-comma-space-after, stylistic/value-list-comma-space-before */
+	/* stylelint-enable @stylistic/value-list-max-empty-lines */
+	/* stylelint-disable-next-line @stylistic/value-list-comma-space-after, @stylistic/value-list-comma-space-before */
 	font-family: serif ,sans-serif;
 	/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 	font-family: serif
-		, sans-serif; /* stylelint-disable-line stylistic/value-list-comma-newline-after, stylistic/value-list-comma-newline-before, stylistic/value-list-comma-space-before */
+		, sans-serif; /* stylelint-disable-line @stylistic/value-list-comma-newline-after, @stylistic/value-list-comma-newline-before, @stylistic/value-list-comma-space-before */
 }
 
 .v {
@@ -285,5 +285,5 @@ a:nth-child( 0n+0 ) {
 
 .last {
 	color: #fff;
-	/* stylelint-disable-next-line stylistic/no-missing-end-of-source-newline */
+	/* stylelint-disable-next-line @stylistic/no-missing-end-of-source-newline */
 }

--- a/test/fixtures/default/invalid.windows.css
+++ b/test/fixtures/default/invalid.windows.css
@@ -1,4 +1,4 @@
-/* stylelint-disable stylistic/linebreaks */
+/* stylelint-disable @stylistic/linebreaks */
 /* This file has Windows line endings */
 div {
 	width: 1px;

--- a/test/fixtures/default/valid.css
+++ b/test/fixtures/default/valid.css
@@ -2,7 +2,7 @@ div {
 	/* Valid: font-family-no-duplicate-names's ignoreFontFamilyNames option */
 	font-family: monospace, monospace;
 
-	/* Off: stylistic/max-line-length */
+	/* Off: @stylistic/max-line-length */
 	content: 'hello this is a very silly, indeed ludicrously long line of text that would get set as the content block for something mostly to test out the line length';
 
 	/* Off: media-query-no-invalid */

--- a/test/fixtures/default/valid.less
+++ b/test/fixtures/default/valid.less
@@ -2,7 +2,7 @@ div {
 	// Off: function-no-unknown
 	color: lighten( #fc0, 50% );
 
-	// Off: stylistic/max-line-length
+	// Off: @stylistic/max-line-length
 	content: 'hello this is a very silly, indeed ludicrously long line of text that would get set as the content block for something mostly to test out the line length';
 }
 

--- a/test/fixtures/default/valid.vue
+++ b/test/fixtures/default/valid.vue
@@ -7,7 +7,7 @@
 
 <style>
 	a {
-		/* Off: stylistic/max-line-length */
+		/* Off: @stylistic/max-line-length */
 		content: 'hello this is a very silly, indeed ludicrously long line of text that would get set as the content block for something mostly to test out the line length';
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,7 @@ QUnit.module( 'package.json', () => {
 						// Disabled rules are covered later
 						if ( isEnabled( rule ) && !tested[ ruleValueIndex ] ) {
 							// eslint-disable-next-line security/detect-non-literal-regexp
-							const disableRulePattern = new RegExp( `(/[/*]|<!--|#) (skip-)?stylelint-disable((-next)?-line)? ([a-z-/]+, ?)*?${ rule }($|[^a-z-])` );
+							const disableRulePattern = new RegExp( `(/[/*]|<!--|#) (skip-)?stylelint-disable((-next)?-line)? ([a-z-/@]+, ?)*?${ rule }($|[^a-z-/])` );
 							assert.true( disableRulePattern.test( invalidFixtures ), `Rule '${ rule }' is covered in invalid fixture` );
 							tested[ ruleValueIndex ] = true;
 						}


### PR DESCRIPTION
Also
- changing to '@stylistic/stylelint-plugin' as 'stylelint-stylistic' isn't compatible with Stylelint 16 anymore
- removing Node 16 from the CI as it's not supported by Stylelint 16

Fixes #10