### PR TITLE
Upgrade stylelint from 16.2.0 to 16.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"browserslist-config-wikimedia": "0.7.0",
 				"postcss-html": "1.6.0",
 				"postcss-less": "6.0.0",
-				"stylelint": "16.2.0",
+				"stylelint": "16.7.0",
 				"stylelint-config-recommended": "14.0.0",
 				"stylelint-no-unsupported-browser-features": "8.0.1"
 			},
@@ -137,9 +137,9 @@
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
-			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
+			"integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
 			"funding": [
 				{
 					"type": "github",
@@ -150,17 +150,18 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^2.3.1"
+				"@csstools/css-tokenizer": "^2.4.1"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
-			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz",
+			"integrity": "sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==",
 			"funding": [
 				{
 					"type": "github",
@@ -171,14 +172,15 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			}
 		},
 		"node_modules/@csstools/media-query-list-parser": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
-			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
+			"integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
 			"funding": [
 				{
 					"type": "github",
@@ -189,12 +191,13 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^2.6.3",
-				"@csstools/css-tokenizer": "^2.3.1"
+				"@csstools/css-parser-algorithms": "^2.7.1",
+				"@csstools/css-tokenizer": "^2.4.1"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
@@ -216,6 +219,16 @@
 			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.13"
+			}
+		},
+		"node_modules/@dual-bundle/import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
@@ -680,6 +693,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -1004,9 +1018,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1874,6 +1889,12 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-uri": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+			"license": "MIT"
+		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2408,9 +2429,10 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
-			"integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
+			"integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
+			"license": "MIT"
 		},
 		"node_modules/ldjson-stream": {
 			"version": "1.2.1",
@@ -2475,7 +2497,8 @@
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+			"license": "MIT"
 		},
 		"node_modules/mathml-tag-names": {
 			"version": "2.1.3",
@@ -2511,11 +2534,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -2783,9 +2807,10 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -2809,9 +2834,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.33",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+			"version": "8.4.40",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+			"integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2826,10 +2851,11 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"picocolors": "^1.0.1",
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -2881,9 +2907,10 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.16",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-			"integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
+			"integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -2910,6 +2937,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3120,6 +3148,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3299,6 +3328,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -3320,9 +3350,10 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3447,47 +3478,59 @@
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
 		},
 		"node_modules/stylelint": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.0.tgz",
-			"integrity": "sha512-gwqU5AkIb52wrAzzn+359S3NIJDMl02TXLUaV2tzA/L6jUdpTwNt+MCxHlc8+Hb2bUHlYVo92YeSIryF2gJthA==",
+			"version": "16.7.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.7.0.tgz",
+			"integrity": "sha512-Q1ATiXlz+wYr37a7TGsfvqYn2nSR3T/isw3IWlZQzFzCNoACHuGBb6xBplZXz56/uDRJHIygxjh7jbV/8isewA==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/stylelint"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/stylelint"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.5.0",
-				"@csstools/css-tokenizer": "^2.2.3",
-				"@csstools/media-query-list-parser": "^2.1.7",
-				"@csstools/selector-specificity": "^3.0.1",
+				"@csstools/css-parser-algorithms": "^2.7.1",
+				"@csstools/css-tokenizer": "^2.4.1",
+				"@csstools/media-query-list-parser": "^2.1.13",
+				"@csstools/selector-specificity": "^3.1.1",
+				"@dual-bundle/import-meta-resolve": "^4.1.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.1",
+				"css-functions-list": "^3.2.2",
 				"css-tree": "^2.3.1",
-				"debug": "^4.3.4",
+				"debug": "^4.3.5",
 				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^8.0.0",
+				"file-entry-cache": "^9.0.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.3.0",
+				"ignore": "^5.3.1",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.29.0",
+				"known-css-properties": "^0.34.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.1.0",
-				"micromatch": "^4.0.5",
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
 				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.4.33",
+				"picocolors": "^1.0.1",
+				"postcss": "^8.4.39",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^7.0.0",
-				"postcss-selector-parser": "^6.0.15",
+				"postcss-selector-parser": "^6.1.0",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^7.1.0",
 				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.8.1",
+				"table": "^6.8.2",
 				"write-file-atomic": "^5.0.1"
 			},
 			"bin": {
@@ -3495,10 +3538,6 @@
 			},
 			"engines": {
 				"node": ">=18.12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/stylelint"
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
@@ -3544,26 +3583,28 @@
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+			"integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
+			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^4.0.0"
+				"flat-cache": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+			"license": "MIT",
 			"dependencies": {
-				"flatted": "^3.2.9",
+				"flatted": "^3.3.1",
 				"keyv": "^4.5.4"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/stylelint/node_modules/postcss-safe-parser": {
@@ -3655,9 +3696,10 @@
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
 		},
 		"node_modules/table": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+			"integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -3670,14 +3712,15 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
-			"integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -3687,7 +3730,8 @@
 		"node_modules/table/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
@@ -3830,6 +3874,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -4114,20 +4159,20 @@
 			}
 		},
 		"@csstools/css-parser-algorithms": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
-			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
+			"integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
 			"requires": {}
 		},
 		"@csstools/css-tokenizer": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
-			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g=="
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz",
+			"integrity": "sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg=="
 		},
 		"@csstools/media-query-list-parser": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
-			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
+			"integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
 			"requires": {}
 		},
 		"@csstools/selector-specificity": {
@@ -4135,6 +4180,11 @@
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
 			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
 			"requires": {}
+		},
+		"@dual-bundle/import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg=="
 		},
 		"@es-joy/jsdoccomment": {
 			"version": "0.43.1",
@@ -4657,9 +4707,9 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -5269,6 +5319,11 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"fast-uri": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+		},
 		"fastest-levenshtein": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -5662,9 +5717,9 @@
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"known-css-properties": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
-			"integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
+			"integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ=="
 		},
 		"ldjson-stream": {
 			"version": "1.2.1",
@@ -5743,11 +5798,11 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
 			"requires": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			}
 		},
@@ -5933,9 +5988,9 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -5949,13 +6004,13 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.33",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+			"version": "8.4.40",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+			"integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
 			"requires": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"picocolors": "^1.0.1",
+				"source-map-js": "^1.2.0"
 			}
 		},
 		"postcss-html": {
@@ -5987,9 +6042,9 @@
 			"requires": {}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.16",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-			"integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
+			"integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -6009,7 +6064,8 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -6264,9 +6320,9 @@
 			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
 		},
 		"source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
 		},
 		"spdx-correct": {
 			"version": "3.2.0",
@@ -6369,47 +6425,48 @@
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
 		},
 		"stylelint": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.0.tgz",
-			"integrity": "sha512-gwqU5AkIb52wrAzzn+359S3NIJDMl02TXLUaV2tzA/L6jUdpTwNt+MCxHlc8+Hb2bUHlYVo92YeSIryF2gJthA==",
+			"version": "16.7.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.7.0.tgz",
+			"integrity": "sha512-Q1ATiXlz+wYr37a7TGsfvqYn2nSR3T/isw3IWlZQzFzCNoACHuGBb6xBplZXz56/uDRJHIygxjh7jbV/8isewA==",
 			"requires": {
-				"@csstools/css-parser-algorithms": "^2.5.0",
-				"@csstools/css-tokenizer": "^2.2.3",
-				"@csstools/media-query-list-parser": "^2.1.7",
-				"@csstools/selector-specificity": "^3.0.1",
+				"@csstools/css-parser-algorithms": "^2.7.1",
+				"@csstools/css-tokenizer": "^2.4.1",
+				"@csstools/media-query-list-parser": "^2.1.13",
+				"@csstools/selector-specificity": "^3.1.1",
+				"@dual-bundle/import-meta-resolve": "^4.1.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.1",
+				"css-functions-list": "^3.2.2",
 				"css-tree": "^2.3.1",
-				"debug": "^4.3.4",
+				"debug": "^4.3.5",
 				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^8.0.0",
+				"file-entry-cache": "^9.0.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.3.0",
+				"ignore": "^5.3.1",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.29.0",
+				"known-css-properties": "^0.34.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.1.0",
-				"micromatch": "^4.0.5",
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
 				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.4.33",
+				"picocolors": "^1.0.1",
+				"postcss": "^8.4.39",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^7.0.0",
-				"postcss-selector-parser": "^6.0.15",
+				"postcss-selector-parser": "^6.1.0",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^7.1.0",
 				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.8.1",
+				"table": "^6.8.2",
 				"write-file-atomic": "^5.0.1"
 			},
 			"dependencies": {
@@ -6424,19 +6481,19 @@
 					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
 				},
 				"file-entry-cache": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-					"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+					"integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
 					"requires": {
-						"flat-cache": "^4.0.0"
+						"flat-cache": "^5.0.0"
 					}
 				},
 				"flat-cache": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-					"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+					"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
 					"requires": {
-						"flatted": "^3.2.9",
+						"flatted": "^3.3.1",
 						"keyv": "^4.5.4"
 					}
 				},
@@ -6505,9 +6562,9 @@
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
 		},
 		"table": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+			"integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
 			"requires": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -6517,14 +6574,14 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.14.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
-					"integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
+					"version": "8.17.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
+						"fast-uri": "^3.0.1",
 						"json-schema-traverse": "^1.0.0",
-						"require-from-string": "^2.0.2",
-						"uri-js": "^4.4.1"
+						"require-from-string": "^2.0.2"
 					}
 				},
 				"json-schema-traverse": {
@@ -6621,6 +6678,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"browserslist-config-wikimedia": "0.7.0",
 		"postcss-less": "6.0.0",
 		"postcss-html": "1.6.0",
-		"stylelint": "16.2.0",
+		"stylelint": "16.7.0",
 		"stylelint-config-recommended": "14.0.0",
 		"stylelint-no-unsupported-browser-features": "8.0.1",
 		"@stylistic/stylelint-config": "1.0.1",

--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -59,12 +59,11 @@ span {
 }
 
 .e {
-	/* stylelint-disable-next-line custom-property-no-missing-var-function */
+	/* stylelint-disable-next-line custom-property-no-missing-var-function, declaration-block-no-duplicate-properties */
 	color: --foo;
 	/* stylelint-disable-next-line @stylistic/declaration-bang-space-after, @stylistic/declaration-bang-space-before, declaration-no-important */
 	color: #fff! important;
 	background: #fff;
-	/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 	color: #fff;
 	--custom-property: #fff;
 	/* stylelint-disable-next-line declaration-block-no-duplicate-custom-properties */
@@ -271,9 +270,8 @@ a:nth-child( 0n+0 ) {
 
 		2px;
 	/* stylelint-enable @stylistic/value-list-max-empty-lines */
-	/* stylelint-disable-next-line @stylistic/value-list-comma-space-after, @stylistic/value-list-comma-space-before */
+	/* stylelint-disable-next-line @stylistic/value-list-comma-space-after, @stylistic/value-list-comma-space-before, declaration-block-no-duplicate-properties */
 	font-family: serif ,sans-serif;
-	/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 	font-family: serif
 		, sans-serif; /* stylelint-disable-line @stylistic/value-list-comma-newline-after, @stylistic/value-list-comma-newline-before, @stylistic/value-list-comma-space-before */
 }


### PR DESCRIPTION
With Stylelint 16.7.0 we made some fixes to `declaration-block-no-duplicate-properties` which requires moving the disable comments.