### PR TITLE
Fix `--report-needless-disables` fixture for stylelint@17.4.0

### DIFF
--- a/test/fixtures/default/invalid.css
+++ b/test/fixtures/default/invalid.css
@@ -194,8 +194,10 @@ span {
 
 /* stylelint-disable-next-line no-descending-specificity, no-duplicate-selectors */
 .k {
-	/* stylelint-disable-next-line no-invalid-double-slash-comments, property-no-unknown */
+	/* stylelint-disable-next-line no-invalid-double-slash-comments */
 	//color: #fff;
+	/* stylelint-disable-next-line property-no-unknown */
+	unknown: #fff;
 	/* stylelint-disable-next-line @stylistic/no-extra-semicolons */
 	;
 	/* stylelint-disable-next-line no-unknown-animations */


### PR DESCRIPTION
In [`17.4.0`](https://stylelint.io/changelog/#1740---2026-02-25), we fixed a false positive bug in the `property-no-unknown` rule for double-slashed properties.

For example:

```css
a { 
  //color:red;
}
```

This PR updates the `default/invalid.css` to reflect that and can be applied when updating to `stylelint@17.4.0` or above.

Ref: https://github.com/stylelint/stylelint/pull/9113#issuecomment-3959068917