### PR TITLE
rules: Apply Less overrides to Vue files as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,16 @@ module.exports = {
 		// Vue support requires special over-rides for a customSyntax; note that these don't inherit
 		{
 			"files": [ "**/*.vue" ],
-			"customSyntax": "postcss-less"
+			"customSyntax": "postcss-less",
+			"rules": {
+				// Less functions, e.g. color functions like `lighten()`, are not supported
+				// by this rule.
+				"declaration-property-value-no-unknown": null,
+				// Less functions are not supported by this rule.
+				"function-no-unknown": null,
+				// Less supports additional media features, rule only applies to CSS.
+				"media-feature-name-value-no-unknown": null
+			}
 		},
 		{
 			"files": [ "**/*.vue" ],

--- a/test/fixtures/basic/valid.vue
+++ b/test/fixtures/basic/valid.vue
@@ -6,5 +6,7 @@
 </script>
 
 <style>
-	/* This comment is here to prevent no-empty-source errors */
+	/* Off: declaration-property-value-no-unknown */
+	/* Off: function-no-unknown */
+	/* Off: media-feature-name-value-no-unknown */
 </style>

--- a/test/fixtures/default/valid.vue
+++ b/test/fixtures/default/valid.vue
@@ -20,4 +20,7 @@
 	/* Off: comment-word-disallowed-list */
 	/* Off: property-no-deprecated */
 	/* Off: property-no-unknown */
+	/* Off: declaration-property-value-no-unknown */
+	/* Off: function-no-unknown */
+	/* Off: media-feature-name-value-no-unknown */
 </style>

--- a/test/fixtures/modern/valid.vue
+++ b/test/fixtures/modern/valid.vue
@@ -6,5 +6,7 @@
 </script>
 
 <style>
-	/* This comment is here to prevent no-empty-source errors */
+	/* Off: declaration-property-value-no-unknown */
+	/* Off: function-no-unknown */
+	/* Off: media-feature-name-value-no-unknown */
 </style>


### PR DESCRIPTION
Need to duplicate them in order to have them apply to the `<style>` blocks in the .vue files as well.