### PR TITLE
Fix exports to correct entry points for support-basic and support-modern

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
 	"exports": {
 		".": "./index.js",
 		"./mediawiki": "./mediawiki.js",
-		"./support-basic": "./support-basic-rules.js",
-		"./support-modern": "./support-modern-rules.js"
+		"./support-basic": "./support-basic.json",
+		"./support-modern": "./support-modern.json"
 	},
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
Pointing the entry points to JSON files to include the base rules from 'index.js'.
By accessing '*-rules.js directly, bypassing 'support-modern.json' the base rules from 'index.js' were never loaded.

Bug: #267