### PR TITLE
rules: Exclude 2 `at-rule-*` rules for Less files

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,6 +185,12 @@ module.exports = {
 			"files": [ "**/*.less" ],
 			"customSyntax": "postcss-less",
 			"rules": {
+				// Less property interpolation (e.g. `@{varname}: value`) inside CSS at-rules
+				// that accept descriptors (e.g. `@font-face`) is parsed by postcss-less as a
+				// standard declaration, causing false positives.
+				"at-rule-descriptor-no-unknown": null,
+				// Less imports with `@import ( reference )` are valid, but not in CSS.
+				"at-rule-prelude-no-invalid": null,
 				// Less functions, e.g. color functions like `lighten()`, are not supported
 				// by this rule.
 				"declaration-property-value-no-unknown": null,
@@ -206,6 +212,12 @@ module.exports = {
 			"files": [ "**/*.vue" ],
 			"customSyntax": "postcss-less",
 			"rules": {
+				// Less property interpolation (e.g. `@{varname}: value`) inside CSS at-rules
+				// that accept descriptors (e.g. `@font-face`) is parsed by postcss-less as a
+				// standard declaration, causing false positives.
+				"at-rule-descriptor-no-unknown": null,
+				// Less imports with `@import ( reference )` are valid, but not in CSS.
+				"at-rule-prelude-no-invalid": null,
 				// Less functions, e.g. color functions like `lighten()`, are not supported
 				// by this rule.
 				"declaration-property-value-no-unknown": null,

--- a/test/fixtures/basic/valid.less
+++ b/test/fixtures/basic/valid.less
@@ -11,6 +11,18 @@ div {
 	/* This comment is here to prevent no-empty-source errors */
 }
 
+// Off: at-rule-descriptor-no-unknown
+@desc: font-display;
+
+@font-face {
+	font-family: 'MyFont';
+	src: url( myfont.woff2 );
+	@{desc}: swap;
+}
+
+// Off: at-rule-prelude-no-invalid
+@import ( reference ) 'importRef.less';
+
 // Off: no-invalid-position-at-import-rule
 @import 'importAfterRule.less';
 

--- a/test/fixtures/basic/valid.vue
+++ b/test/fixtures/basic/valid.vue
@@ -6,6 +6,8 @@
 </script>
 
 <style>
+	/* Off: at-rule-descriptor-no-unknown */
+	/* Off: at-rule-prelude-no-invalid */
 	/* Off: declaration-property-value-no-unknown */
 	/* Off: function-no-unknown */
 	/* Off: media-feature-name-value-no-unknown */

--- a/test/fixtures/default/valid.less
+++ b/test/fixtures/default/valid.less
@@ -11,6 +11,18 @@ div {
 	/* This comment is here to prevent no-empty-source errors */
 }
 
+// Off: at-rule-descriptor-no-unknown
+@desc: font-display;
+
+@font-face {
+	font-family: 'MyFont';
+	src: url( myfont.woff2 );
+	@{desc}: swap;
+}
+
+// Off: at-rule-prelude-no-invalid
+@import ( reference ) 'importRef.less';
+
 // Off: no-invalid-position-at-import-rule
 @import 'importAfterRule.less';
 

--- a/test/fixtures/default/valid.vue
+++ b/test/fixtures/default/valid.vue
@@ -16,6 +16,8 @@
 		/* This comment is here to prevent no-empty-source errors */
 	}
 
+	/* Off: at-rule-descriptor-no-unknown */
+	/* Off: at-rule-prelude-no-invalid */
 	/* Off: string-no-newline */
 	/* Off: comment-word-disallowed-list */
 	/* Off: property-no-deprecated */

--- a/test/fixtures/modern/valid.less
+++ b/test/fixtures/modern/valid.less
@@ -11,6 +11,18 @@ div {
 	/* This comment is here to prevent no-empty-source errors */
 }
 
+// Off: at-rule-descriptor-no-unknown
+@desc: font-display;
+
+@font-face {
+	font-family: 'MyFont';
+	src: url( myfont.woff2 );
+	@{desc}: swap;
+}
+
+// Off: at-rule-prelude-no-invalid
+@import ( reference ) 'importRef.less';
+
 // Off: no-invalid-position-at-import-rule
 @import 'importAfterRule.less';
 

--- a/test/fixtures/modern/valid.vue
+++ b/test/fixtures/modern/valid.vue
@@ -6,6 +6,8 @@
 </script>
 
 <style>
+	/* Off: at-rule-descriptor-no-unknown */
+	/* Off: at-rule-prelude-no-invalid */
 	/* Off: declaration-property-value-no-unknown */
 	/* Off: function-no-unknown */
 	/* Off: media-feature-name-value-no-unknown */


### PR DESCRIPTION
Make it understand
1. Less property interpolation (e.g. `@{varname}: value`) inside CSS at-rules
2. Less-specific syntax like `@import ( reference )`